### PR TITLE
feat: Enhance component management in ApplicationContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **PySpring** Framework
 
-#### **PySpring** is a Python web framework inspired by Spring Boot. It combines FastAPI for the web layer, SQLModel for ORM, and Pydantic for data validation. PySpring provides a structured approach to building scalable web applications with `auto dependency injection`, `auto configuration management` and a `web server` for hosting your application.
+#### **PySpring** is a Python web framework inspired by Spring Boot. It combines FastAPI for the web layer, and Pydantic for data validation. PySpring provides a structured approach to building scalable web applications with `auto dependency injection`, `auto configuration management` and a `web server` for hosting your application.
 
 ## Key Features
 - **Application Initialization**: `PySpringApplication` class serves as the main entry point for the **PySpring** application. It initializes the application from a configuration file, scans the application source directory for Python files, and groups them into class files and model files.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # **PySpring** Framework
 
-#### **PySpring** is a Python web framework inspired by Spring Boot. It combines FastAPI for the web layer, SQLModel for ORM, and Pydantic for data validation. PySpring provides a structured approach to building scalable web applications with `auto dependency injection`, `auto configuration management`  and a `web server` for hosting your application.
+#### **PySpring** is a Python web framework inspired by Spring Boot. It combines FastAPI for the web layer, SQLModel for ORM, and Pydantic for data validation. PySpring provides a structured approach to building scalable web applications with `auto dependency injection`, `auto configuration management` and a `web server` for hosting your application.
 
-# Key Features
-- Application Initialization: **PySpringApplication** class serves as the main entry point for the **PySpring** application. It initializes the application from a configuration file, scans the application source directory for Python files, and groups them into class files and model files
+## Key Features
+- **Application Initialization**: `PySpringApplication` class serves as the main entry point for the **PySpring** application. It initializes the application from a configuration file, scans the application source directory for Python files, and groups them into class files and model files.
 
 - **Application Context Management**: **PySpring** manages the application context and dependency injection. It registers application entities such as components, controllers, bean collections, and properties. It also initializes the application context and injects dependencies.
 
@@ -17,24 +17,40 @@
 
 - **Builtin FastAPI Integration**: **PySpring** integrates with `FastAPI`, a modern, fast (high-performance), web framework for building APIs with Python. It leverages FastAPI's features for routing, request handling, and server configuration.
 
-# Getting Started
-To get started with **PySpring**, follow these steps:
+## Project Structure
+```
+PySpring/
+├── src/                    # Source code directory
+├── tests/                  # Test files
+├── logs/                   # Application logs
+├── py_spring_core/         # Core framework package
+├── app-config.json         # Application configuration
+├── application-properties.json  # Application properties
+├── main.py                 # Application entry point
+├── pyproject.toml          # Project metadata and dependencies
+└── README.md              # Project documentation
+```
 
-### 1. Install the **PySpring** framework by running:
+## Getting Started
 
-`pip3 install py-spring-core`
+### Prerequisites
+- Python 3.10 or higher
+- pip (Python package installer)
 
+### Installation
+1. Install the **PySpring** framework:
+```bash
+pip install py-spring-core
+```
 
-### 2. Create a new Python project and navigate to its directory
+2. Create a new Python project and navigate to its directory
 
--  Implement your application properties, components, controllers, using **PySpring** conventions inside declared source code folder (whcih can be modified the key `app_src_target_dir` inside app-config.json), this controls what folder will be scanned by the framework.
+3. Set up your application:
+   - Implement your application properties, components, and controllers using **PySpring** conventions inside the declared source code folder (which can be modified via the `app_src_target_dir` key in `app-config.json`)
+   - Create an `app-config.json` file for your application configuration
+   - Create an `application-properties.json` file for your application properties
 
-- Instantiate a `PySpringApplication` object in your main script, passing the path to your application configuration file.
-
-- Optionally, define and enable any framework modules you want to use.
-
-- Run the application by calling the `run()` method on the `PySpringApplication` object, as shown in the example code below:
-
+4. Create your main application script:
 ```python
 from py_spring_core import PySpringApplication
 
@@ -45,8 +61,49 @@ def main():
 if __name__ == "__main__":
     main()
 ```
-- For example project, please refer to this [github repo](https://github.com/NFUChen/PySpring-Example-Project).
 
-# Contributing
+5. Run your application:
+```bash
+python main.py
+```
 
-Contributions to **PySpring** are welcome! If you find any issues or have suggestions for improvements, please submit a pull request or open an issue on GitHub.
+For a complete example project, please refer to the [PySpring Example Project](https://github.com/NFUChen/PySpring-Example-Project).
+
+## Development Setup
+1. Clone the repository:
+```bash
+git clone https://github.com/NFUChen/PySpring.git
+cd PySpring
+```
+
+2. Install development dependencies:
+```bash
+pip install -e ".[dev]"
+```
+
+3. Run tests:
+```bash
+pytest
+```
+
+## Dependencies
+PySpring relies on several key dependencies:
+- FastAPI (0.112.0)
+- Pydantic (2.8.2)
+- Uvicorn (0.30.5)
+- Loguru (0.7.2)
+- And other supporting packages
+
+For a complete list of dependencies, see `pyproject.toml`.
+
+## Contributing
+
+Contributions to **PySpring** are welcome! If you find any issues or have suggestions for improvements, please:
+1. Fork the repository
+2. Create a feature branch
+3. Commit your changes
+4. Push to the branch
+5. Create a Pull Request
+
+## License
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/py_spring_core/__init__.py
+++ b/py_spring_core/__init__.py
@@ -5,4 +5,4 @@ from py_spring_core.core.entities.controllers.rest_controller import RestControl
 from py_spring_core.core.entities.properties.properties import Properties
 from py_spring_core.core.entities.entity_provider import EntityProvider
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -81,27 +81,6 @@ class ApplicationContext:
             ),
         )
     
-    def _validate_duplicate_primary_components(self, component_cls: Type[ABC]) -> None:
-        primary_count = 0
-        subclasses = component_cls.__subclasses__()
-        for component_cls in subclasses:
-            if not issubclass(component_cls, Component):
-                continue
-            if not component_cls.is_primary():
-                continue
-            primary_count += 1
-            if primary_count > 1:
-                raise ValueError(f"[PRIMARY COMPONENT ERROR] Primary component {component_cls.__name__} is already registered")
-            
-    def _get_primary_component_cls(self, component_cls: Type[ABC]) -> Optional[Type[Component]]:
-        subclasses = component_cls.__subclasses__()
-        for component_cls in subclasses:
-            if not issubclass(component_cls, Component):
-                continue
-            if not component_cls.is_primary():
-                continue
-            return component_cls
-    
     def _determine_target_cls_name(self, component_cls: Type[T], qualifier: Optional[str]) -> str:
         """
         Determine the target class name for a given component class.
@@ -130,13 +109,8 @@ class ApplicationContext:
             raise ValueError(
                 f"[ABSTRACT CLASS ERROR] Abstract class {component_cls.__name__} has no subclasses"
             )
-            
-        self._validate_duplicate_primary_components(component_cls)
         
-        # Try to get primary component first
-        if primary_cls := self._get_primary_component_cls(component_cls):
-            return primary_cls.get_name()
-            
+        
         # Fall back to first subclass if no primary component exists
         return subclasses[0].get_name()
 
@@ -372,7 +346,6 @@ class ApplicationContext:
                     f"[DEPENDENCY INJECTION SUCCESS FROM COMPONENT CONTAINER] Inject dependency for {annotated_entity_cls.__name__} in attribute: {attr_name} with dependency: {annotated_entity_cls.__name__} singleton instance"
                 )
                 continue
-
             error_message = f"[DEPENDENCY INJECTION FAILED] Fail to inject dependency for attribute: {attr_name} with dependency: {annotated_entity_cls.__name__} with qualifier: {qualifier}, consider register such depency with Compoent decorator"
             logger.critical(error_message)
             raise ValueError(error_message)

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from inspect import isclass
-from typing import Callable, Mapping, Optional, Type, TypeVar, cast
+from typing import Annotated, Callable, Mapping, Optional, Type, TypeVar, cast, get_origin, get_args
 
 from loguru import logger
 from pydantic import BaseModel
@@ -103,8 +103,9 @@ class ApplicationContext:
         
             return component_cls
     
-    def _determine_target_cls_name(self, component_cls: Type[T]) -> str:
-        """Determine the target class name for a component class.
+    def _determine_target_cls_name(self, component_cls: Type[T], qualifier: Optional[str]) -> str:
+        """
+        Determine the target class name for a component class.
         
         Args:
             component_cls: The component class to determine the target name for.
@@ -115,6 +116,10 @@ class ApplicationContext:
         Raises:
             ValueError: If the abstract class has no subclasses or if there are multiple primary components.
         """
+
+        if qualifier is not None:
+            return qualifier
+        
         if not issubclass(component_cls, ABC):
             return component_cls.get_name()
             
@@ -130,14 +135,17 @@ class ApplicationContext:
         if primary_cls := self._get_primary_component_cls(component_cls):
             return primary_cls.get_name()
             
+        
+            
         # Fall back to first subclass if no primary component exists
         return subclasses[0].get_name()
 
-    def get_component(self, component_cls: Type[T]) -> Optional[T]:
-        if not issubclass(component_cls, Component):
+    def get_component(self, component_cls: Type[T], qualifier: Optional[str]) -> Optional[T]:
+        if not issubclass(component_cls, (Component, ABC)):
             return None
 
-        target_cls_name: str = self._determine_target_cls_name(component_cls)
+        target_cls_name: str = self._determine_target_cls_name(component_cls, qualifier)
+
         if target_cls_name not in self.component_cls_container:
             return None
 
@@ -166,7 +174,7 @@ class ApplicationContext:
             or is_within_properties
         )
 
-    def get_bean(self, object_cls: Type[T]) -> Optional[T]:
+    def get_bean(self, object_cls: Type[T], qualifier: Optional[str]) -> Optional[T]:
         bean_name = object_cls.__name__
         if bean_name not in self.singleton_bean_instance_container:
             return None
@@ -263,6 +271,20 @@ class ApplicationContext:
             self.singleton_properties_instance_container
         )
 
+    def init_singleton_component(self, component_cls: Type[Component], component_cls_name: str) -> Optional[Component]:
+        instance: Optional[Component] = None
+        try:
+            instance = component_cls()
+        except Exception as error:
+            unable_to_init_component_error_prefix = "Can't instantiate abstract class"
+            if unable_to_init_component_error_prefix in str(error):
+                logger.warning(f"[INITIALIZING SINGLETON COMPONENT ERROR] Skip initializing singleton component: {component_cls_name} because it is an abstract class")
+                return
+            logger.error(f"[INITIALIZING SINGLETON COMPONENT ERROR] Error initializing singleton component: {component_cls_name} with error: {error}")
+            raise error
+        
+        return instance
+
     def init_ioc_container(self) -> None:
         """
         Initializes the IoC (Inversion of Control) container by creating singleton instances of all registered components.
@@ -278,7 +300,9 @@ class ApplicationContext:
             logger.debug(
                 f"[INITIALIZING SINGLETON COMPONENT] Init singleton component: {component_cls_name}"
             )
-            instance = component_cls()
+            instance = self.init_singleton_component(component_cls, component_cls_name)
+            if instance is None:
+                continue
             self.singleton_component_instance_container[component_cls_name] = instance
 
         # for Bean
@@ -307,15 +331,21 @@ class ApplicationContext:
     def _inject_entity_dependencies(self, entity: Type[AppEntities]) -> None:
         for attr_name, annotated_entity_cls in entity.__annotations__.items():
             is_injected: bool = False
+            # Handle Annotated types
+            qualifier: Optional[str] = None
+            if get_origin(annotated_entity_cls) is Annotated:
+                annotated_entity_cls, qualifier_found = get_args(annotated_entity_cls)
+                if qualifier_found:
+                    qualifier = qualifier_found
             if annotated_entity_cls in self.primitive_types:
                 logger.warning(
                     f"[DEPENDENCY INJECTION SKIPPED] Skip inject dependency for attribute: {attr_name} with dependency: {annotated_entity_cls.__name__} because it is primitive type"
                 )
                 continue
-
             if not isclass(annotated_entity_cls):
                 continue
 
+            
             if issubclass(annotated_entity_cls, Properties):
                 optional_properties = self.get_properties(annotated_entity_cls)
                 if optional_properties is None:
@@ -325,10 +355,12 @@ class ApplicationContext:
                 setattr(entity, attr_name, optional_properties)
                 continue
 
-            entity_getters: list[Callable] = [self.get_component, self.get_bean]
+            entity_getters: list[Callable[[Type[AppEntities], Optional[str]], Optional[AppEntities]]] = [
+                self.get_component, self.get_bean
+            ]
 
             for getter in entity_getters:
-                optional_entity = getter(annotated_entity_cls)
+                optional_entity = getter(annotated_entity_cls, qualifier)
                 if optional_entity is not None:
                     setattr(entity, attr_name, optional_entity)
                     is_injected = True
@@ -340,7 +372,7 @@ class ApplicationContext:
                 )
                 continue
 
-            error_message = f"[DEPENDENCY INJECTION FAILED] Fail to inject dependency for attribute: {attr_name} with dependency: {annotated_entity_cls.__name__}, consider register such depency with Compoent decorator"
+            error_message = f"[DEPENDENCY INJECTION FAILED] Fail to inject dependency for attribute: {attr_name} with dependency: {annotated_entity_cls.__name__} with qualifier: {qualifier}, consider register such depency with Compoent decorator"
             logger.critical(error_message)
             raise ValueError(error_message)
 

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -100,29 +100,31 @@ class ApplicationContext:
                 continue
             if not component_cls.is_primary():
                 continue
-        
             return component_cls
     
     def _determine_target_cls_name(self, component_cls: Type[T], qualifier: Optional[str]) -> str:
         """
-        Determine the target class name for a component class.
-        
-        Args:
-            component_cls: The component class to determine the target name for.
-            
-        Returns:
-            str: The name of the target class.
-            
-        Raises:
-            ValueError: If the abstract class has no subclasses or if there are multiple primary components.
+        Determine the target class name for a given component class.
+        This method handles the following cases:
+        1. If a qualifier is provided, return it directly.
+        2. If the component class is not an ABC, return its name directly.
+        3. If the component class is an ABC but has implementations, return its name directly.
+        4. If the component class is an ABC and has no implementations, return the name of the first subclass.
+        5. If the component class is an ABC and has multiple implementations, raise an error.
         """
 
         if qualifier is not None:
             return qualifier
         
+        # If it's not an ABC, return its name directly
         if not issubclass(component_cls, ABC):
             return component_cls.get_name()
+        
+        # If it's an ABC but has implementations, return its name directly
+        if not component_cls.__abstractmethods__:
+            return component_cls.get_name()
             
+        # For abstract classes that need implementations
         subclasses = component_cls.__subclasses__()
         if len(subclasses) == 0:
             raise ValueError(
@@ -134,8 +136,6 @@ class ApplicationContext:
         # Try to get primary component first
         if primary_cls := self._get_primary_component_cls(component_cls):
             return primary_cls.get_name()
-            
-        
             
         # Fall back to first subclass if no primary component exists
         return subclasses[0].get_name()

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -196,8 +196,9 @@ class ApplicationContext:
             raise TypeError(
                 f"[COMPONENT REGISTRATION ERROR] Component: {component_cls} is not a subclass of Component"
             )
-
         component_cls_name = component_cls.get_name()
+        if component_cls_name in self.component_cls_container:
+            raise ValueError(f"[COMPONENT REGISTRATION ERROR] Component: {component_cls_name} already registered")
         self.component_cls_container[component_cls_name] = component_cls
 
     def register_controller(self, controller_cls: Type[RestController]) -> None:

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from inspect import isclass
 from typing import Callable, Mapping, Optional, Type, TypeVar, cast
 
@@ -79,20 +80,72 @@ class ApplicationContext:
                 self.singleton_component_instance_container.keys()
             ),
         )
+    
+    def _validate_duplicate_primary_components(self, component_cls: Type[ABC]) -> None:
+        primary_count = 0
+        subclasses = component_cls.__subclasses__()
+        for component_cls in subclasses:
+            if not issubclass(component_cls, Component):
+                continue
+            if not component_cls.is_primary():
+                continue
+            primary_count += 1
+            if primary_count > 1:
+                raise ValueError(f"[PRIMARY COMPONENT ERROR] Primary component {component_cls.__name__} is already registered")
+            
+    def _get_primary_component_cls(self, component_cls: Type[ABC]) -> Optional[Type[Component]]:
+        subclasses = component_cls.__subclasses__()
+        for component_cls in subclasses:
+            if not issubclass(component_cls, Component):
+                continue
+            if not component_cls.is_primary():
+                continue
+        
+            return component_cls
+    
+    def _determine_target_cls_name(self, component_cls: Type[T]) -> str:
+        """Determine the target class name for a component class.
+        
+        Args:
+            component_cls: The component class to determine the target name for.
+            
+        Returns:
+            str: The name of the target class.
+            
+        Raises:
+            ValueError: If the abstract class has no subclasses or if there are multiple primary components.
+        """
+        if not issubclass(component_cls, ABC):
+            return component_cls.get_name()
+            
+        subclasses = component_cls.__subclasses__()
+        if len(subclasses) == 0:
+            raise ValueError(
+                f"[ABSTRACT CLASS ERROR] Abstract class {component_cls.__name__} has no subclasses"
+            )
+            
+        self._validate_duplicate_primary_components(component_cls)
+        
+        # Try to get primary component first
+        if primary_cls := self._get_primary_component_cls(component_cls):
+            return primary_cls.get_name()
+            
+        # Fall back to first subclass if no primary component exists
+        return subclasses[0].get_name()
 
     def get_component(self, component_cls: Type[T]) -> Optional[T]:
         if not issubclass(component_cls, Component):
             return None
 
-        component_cls_name = component_cls.get_name()
-        if component_cls_name not in self.component_cls_container:
+        target_cls_name: str = self._determine_target_cls_name(component_cls)
+        if target_cls_name not in self.component_cls_container:
             return None
 
         scope = component_cls.get_scope()
         match scope:
             case ComponentScope.Singleton:
                 optional_instance = self.singleton_component_instance_container.get(
-                    component_cls_name
+                    target_cls_name
                 )
                 return cast(T, optional_instance) 
 

--- a/py_spring_core/core/application/py_spring_application.py
+++ b/py_spring_core/core/application/py_spring_application.py
@@ -164,7 +164,6 @@ class PySpringApplication:
         self._register_all_entities_from_providers()
         self._register_app_entities(self.scanned_classes)
         self._register_entity_providers(self.entity_providers)
-        self._type_checking()
         self.app_context.load_properties()
         self.app_context.init_ioc_container()
         self.app_context.inject_dependencies_for_app_entities()
@@ -174,15 +173,6 @@ class PySpringApplication:
 
         self._init_providers(self.entity_providers)
         self._handle_singleton_components_life_cycle(ComponentLifeCycle.Init)
-
-    def _type_checking(self) -> None:
-        optional_error = self.type_checking_service.type_checking()
-        if optional_error is not None:
-            match (self.app_config.type_checking_mode):
-                case TypeCheckingMode.Strict:
-                    raise optional_error
-                case TypeCheckingMode.Basic:
-                    logger.warning(optional_error)
 
     def _handle_singleton_components_life_cycle(
         self, life_cycle: ComponentLifeCycle

--- a/py_spring_core/core/application/py_spring_application.py
+++ b/py_spring_core/core/application/py_spring_application.py
@@ -27,12 +27,6 @@ from py_spring_core.core.entities.controllers.rest_controller import RestControl
 from py_spring_core.core.entities.properties.properties import Properties
 
 
-class ApplicationFileGroups(BaseModel):
-    model_config = ConfigDict(protected_namespaces=())
-    class_files: set[str]
-    model_files: set[str]
-
-
 class PySpringApplication:
     """
     The PySpringApplication class is the main entry point for the PySpring application.
@@ -40,8 +34,6 @@ class PySpringApplication:
 
     The class performs the following key tasks:
     - Initializes the application from a configuration file path
-    - Scans the application source directory for Python files and groups them into class files and model files
-    - Dynamically imports the model modules and creates SQLModel tables
     - Registers application entities (components, controllers, bean collections, properties) with the application context
     - Initializes the application context and injects dependencies
     - Handles the lifecycle of singleton components

--- a/py_spring_core/core/entities/component.py
+++ b/py_spring_core/core/entities/component.py
@@ -43,7 +43,6 @@ class Component:
     class Config:
         name: str = ""
         scope: ComponentScope = ComponentScope.Singleton
-        is_primary: bool = False
 
     @classmethod
     def get_name(cls) -> str:
@@ -54,10 +53,6 @@ class Component:
     @classmethod
     def get_component_base(cls) -> "Type[Component]":
         return cls
-
-    @classmethod
-    def is_primary(cls) -> bool:
-        return cls.Config.is_primary
 
     @classmethod
     def get_scope(cls) -> ComponentScope:

--- a/py_spring_core/core/entities/component.py
+++ b/py_spring_core/core/entities/component.py
@@ -42,6 +42,7 @@ class Component:
 
     class Config:
         scope: ComponentScope = ComponentScope.Singleton
+        is_primary: bool = False
 
     @classmethod
     def get_name(cls) -> str:
@@ -50,6 +51,10 @@ class Component:
     @classmethod
     def get_component_base(cls) -> "Type[Component]":
         return cls
+
+    @classmethod
+    def is_primary(cls) -> bool:
+        return cls.Config.is_primary
 
     @classmethod
     def get_scope(cls) -> ComponentScope:

--- a/py_spring_core/core/entities/component.py
+++ b/py_spring_core/core/entities/component.py
@@ -41,11 +41,14 @@ class Component:
     """
 
     class Config:
+        name: str = ""
         scope: ComponentScope = ComponentScope.Singleton
         is_primary: bool = False
 
     @classmethod
     def get_name(cls) -> str:
+        if hasattr(cls.Config, "name") and cls.Config.name:
+            return cls.Config.name
         return cls.__name__
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "py_spring_core"
 dynamic = ["version"]
-description = "PySpring is a Python web framework inspired by Spring Boot, combining FastAPI, SQLModel, and Pydantic for building scalable web applications with auto dependency injection, configuration management, and a web server."
+description = "PySpring is a Python web framework inspired by Spring Boot, combining FastAPI, and Pydantic for building scalable web applications with auto dependency injection, configuration management, and a web server."
 authors = [
     {name = "William Chen", email = "OW6201231@gmail.com"},
 ]

--- a/tests/test_application_context.py
+++ b/tests/test_application_context.py
@@ -126,7 +126,7 @@ class TestApplicationContext:
         app_context.singleton_component_instance_container["TestComponent"] = (
             component_instance
         )
-        retrieved_component = app_context.get_component(TestComponent)
+        retrieved_component = app_context.get_component(TestComponent, None)
         assert retrieved_component is component_instance
 
         # Test retrieving singleton beans
@@ -134,7 +134,7 @@ class TestApplicationContext:
         app_context.singleton_bean_instance_container["TestBeanCollection"] = (
             bean_instance
         )
-        retrieved_bean = app_context.get_bean(TestBeanCollection)
+        retrieved_bean = app_context.get_bean(TestBeanCollection, None)
         assert retrieved_bean is bean_instance
 
         # Test retrieving singleton properties

--- a/tests/test_component_features.py
+++ b/tests/test_component_features.py
@@ -1,0 +1,189 @@
+from abc import ABC
+import pytest
+from typing import Annotated
+
+from py_spring_core.core.application.context.application_context import (
+    ApplicationContext,
+    ApplicationContextConfig
+)
+from py_spring_core.core.entities.component import Component
+from py_spring_core.core.entities.component import ComponentScope
+
+
+class TestComponentFeatures:
+    """Test suite for component features including primary components, qualifiers, and registration validation."""
+
+    @pytest.fixture
+    def app_context(self):
+        """Fixture that provides a fresh ApplicationContext instance for each test."""
+        config = ApplicationContextConfig(properties_path="")
+        return ApplicationContext(config)
+
+    def test_qualifier_based_injection(self, app_context: ApplicationContext):
+        """
+        Test the qualifier-based dependency injection mechanism.
+
+        This test verifies that:
+        1. Multiple implementations of an abstract component can coexist
+        2. Specific implementations can be injected using qualifiers
+        3. Both primary and non-primary components can be injected using qualifiers
+        4. The correct implementation is injected for each qualifier
+
+        The test creates an abstract service with two implementations and verifies
+        that each can be injected into a consumer using appropriate qualifiers.
+        """
+        # Define abstract base class
+        class AbstractService(Component):
+            class Config:
+                is_primary = True
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                raise NotImplementedError()
+
+        # Define implementations
+        class ServiceA(AbstractService):
+            class Config:
+                is_primary = True
+                name = "ServiceA"
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                return "Service A processing"
+
+        class ServiceB(AbstractService):
+            class Config:
+                is_primary = False
+                name = "ServiceB"
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                return "Service B processing"
+
+        # Register implementations
+        app_context.register_component(ServiceA)
+        app_context.register_component(ServiceB)
+        app_context.init_ioc_container()
+
+        # Test qualifier-based injection
+        class ServiceConsumer(Component):
+            service_a: Annotated[AbstractService, "ServiceA"]
+            service_b: Annotated[AbstractService, "ServiceB"]
+
+            def post_construct(self) -> None:
+                assert isinstance(self.service_a, ServiceA)
+                assert isinstance(self.service_b, ServiceB)
+                assert self.service_a.process() == "Service A processing"
+                assert self.service_b.process() == "Service B processing"
+
+        app_context.register_component(ServiceConsumer)
+        app_context.init_ioc_container()  # Initialize the consumer component
+        app_context.inject_dependencies_for_app_entities()
+
+    def test_duplicate_component_registration(self, app_context: ApplicationContext):
+        """
+        Test the prevention of duplicate component registration.
+
+        This test verifies that:
+        1. A component can only be registered once
+        2. Attempting to register the same component again raises an error
+        3. The error message clearly indicates the duplicate registration
+
+        The test attempts to register the same component twice and verifies
+        that an appropriate error is raised.
+        """
+        # Define a component
+        class TestService(Component):
+            class Config:
+                name = "TestService"
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                return "Test service processing"
+
+        # Register component first time
+        app_context.register_component(TestService)
+        app_context.init_ioc_container()
+
+        # Attempt to register same component again should raise error
+        with pytest.raises(ValueError, match="\\[COMPONENT REGISTRATION ERROR\\] Component: TestService already registered"):
+            app_context.register_component(TestService)
+            app_context.init_ioc_container()
+
+    def test_component_name_override(self, app_context: ApplicationContext):
+        """
+        Test the ability to override component names during registration.
+
+        This test verifies that:
+        1. Components can be registered with custom names
+        2. The custom name is correctly stored in the component container
+        3. The component can be retrieved using the custom name
+
+        The test registers a component with a custom name and verifies
+        that it is correctly stored in the container.
+        """
+        # Define component with custom name
+        class TestService(Component):
+            class Config:
+                name = "CustomServiceName"
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                return "Test service processing"
+
+        # Register component
+        app_context.register_component(TestService)
+        app_context.init_ioc_container()
+
+        # Verify component is registered with custom name
+        assert "CustomServiceName" in app_context.component_cls_container
+        assert app_context.component_cls_container["CustomServiceName"] == TestService
+
+    def test_qualifier_with_invalid_component(self, app_context: ApplicationContext):
+        """
+        Test error handling for invalid qualifier usage.
+
+        This test verifies that:
+        1. Attempting to inject a component with an invalid qualifier raises an error
+        2. The error message clearly indicates the invalid qualifier
+        3. The error occurs during dependency injection
+
+        The test attempts to inject a component using a non-existent qualifier
+        and verifies that an appropriate error is raised.
+        """
+        # Define abstract base class
+        class AbstractService(Component):
+            class Config:
+                is_primary = True
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                raise NotImplementedError()
+
+        # Define implementation
+        class TestService(AbstractService):
+            class Config:
+                is_primary = True
+                name = "TestService"
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                return "Test service processing"
+
+        # Register implementation
+        app_context.register_component(TestService)
+        app_context.init_ioc_container()
+
+        # Test injection with invalid qualifier
+        class ServiceConsumer(Component):
+            service: Annotated[AbstractService, "NonExistentService"]
+
+            def post_construct(self) -> None:
+                pass
+
+        app_context.register_component(ServiceConsumer)
+        app_context.init_ioc_container()  # Initialize the consumer component
+
+        # Attempting to inject with invalid qualifier should raise error
+        with pytest.raises(ValueError, match="\\[DEPENDENCY INJECTION FAILED\\] Fail to inject dependency for attribute: service with dependency: AbstractService with qualifier: NonExistentService"):
+            app_context.inject_dependencies_for_app_entities() 


### PR DESCRIPTION
# Add Support for Qualifiers and Component Registration Validation

## Changes Overview
This PR introduces two major features to enhance component management in PySpring:

1. **Qualifier Support**
   - Added support for qualifiers in dependency injection
   - Implemented handling of `Annotated` types for qualifier-based injection
   - Enhanced error messages to include qualifier information

2. **Component Registration Validation**
   - Added validation to prevent duplicate component registration
   - Enhanced error handling with clear feedback for developers
   - Improved component registration robustness

## Key Changes

### Component Class Enhancements
- Added `name` configuration option to `Component.Config`
- Enhanced `get_name()` to support custom component names

### Application Context Improvements
- Simplified component registration process
- Added `_determine_target_cls_name()` to handle component resolution logic
- Enhanced dependency injection to support qualifiers
- Improved error handling for component initialization
- Added duplicate component registration prevention

### Dependency Injection Updates
- Modified `get_component()` and `get_bean()` to accept qualifier parameter
- Enhanced type hints for entity getters
- Improved error messages with qualifier information

### Other Changes
- Removed type checking service as it's no longer needed
- Added better error handling for component initialization

## Example Usage

### 1. Using Qualifiers for Dependency Injection
```python
from typing import Annotated
from py_spring_core import Component

class ServiceConsumer(Component):
    # Will inject the specifically qualified implementation
    service_a: Annotated[AbstractService, "ServiceA"]
    service_b: Annotated[AbstractService, "ServiceB"]

    def post_construct(self) -> None:
        print(self.service_a.process())  # Uses ServiceA
        print(self.service_b.process())  # Uses ServiceB
```

### 2. Complete Working Example
```python
from abc import ABC, abstractmethod
from typing import Annotated
from py_spring_core import Component
from py_spring_core.core.entities.component import ComponentScope

# Abstract base class
class AbstractExample(Component, ABC):
    class Config:
        scope = ComponentScope.Singleton

    @abstractmethod
    def say_hello(self) -> str: ...

# First implementation
class ExampleA(AbstractExample):
    class Config:
        name = "ExampleA"
        scope = ComponentScope.Singleton

    def say_hello(self) -> str:
        return "Hello from Example A!"

# Second implementation
class ExampleB(AbstractExample):
    class Config:
        name = "ExampleB"
        scope = ComponentScope.Singleton

    def say_hello(self) -> str:
        return "Hello from Example B!"

# Service using both implementations
class TestService(Component):
    # Will inject the specifically qualified implementations
    example_a: Annotated[AbstractExample, "ExampleA"]
    example_b: Annotated[AbstractExample, "ExampleB"]

    def post_construct(self) -> None:
        print(self.example_a.say_hello())  # Output: "Hello from Example A!"
        print(self.example_b.say_hello())  # Output: "Hello from Example B!"
```

### 3. Duplicate Registration Prevention Example
```python
from py_spring_core import Component
from py_spring_core.core.entities.component import ComponentScope

# First registration of MyService
class MyService(Component):
    class Config:
        name = "MyService"
        scope = ComponentScope.Singleton

    def do_something(self) -> str:
        return "Service is working!"

# Attempting to register the same component again will raise ValueError
try:
    class MyService(Component):  # This will raise ValueError
        class Config:
            name = "MyService"
            scope = ComponentScope.Singleton

        def do_something(self) -> str:
            return "This will never be registered!"
except ValueError as e:
    print(f"Error: {e}")  # Output: "Error: [COMPONENT REGISTRATION ERROR] Component: MyService already registered"
```

### Key Points to Remember:
1. Use `Annotated[Type, "QualifierName"]` to inject specific implementations
2. The `name` in `Config` can be used to override the default class name
3. All components must have a valid implementation of the abstract methods
4. Components can only be registered once with the same name

## Testing
Please test the following scenarios:
1. Dependency injection with qualifiers
2. Error cases for duplicate component registration
3. Abstract class initialization handling

## Breaking Changes
- `get_component()` and `get_bean()` now require a qualifier parameter (can be None)
- Type checking service has been removed
- Primary component validation has been removed