### PR TITLE
Dependency Updates and Configuration Cleanup

### DIFF
--- a/py_spring_core/__init__.py
+++ b/py_spring_core/__init__.py
@@ -5,4 +5,4 @@ from py_spring_core.core.entities.controllers.rest_controller import RestControl
 from py_spring_core.core.entities.properties.properties import Properties
 from py_spring_core.core.entities.entity_provider import EntityProvider
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/py_spring_core/core/application/application_config.py
+++ b/py_spring_core/core/application/application_config.py
@@ -21,11 +21,6 @@ class ServerConfig(BaseModel):
     port: int
     enabled: bool = Field(default=True)
 
-class TypeCheckingMode(str, Enum):
-    """Basic will only warning the user, strict will raise an error"""
-    Basic = "basic"
-    Strict = "strict"
-
 class ApplicationConfig(BaseModel):
     """
     Represents the configuration for the application.
@@ -44,8 +39,6 @@ class ApplicationConfig(BaseModel):
     server_config: ServerConfig
     properties_file_path: str
     loguru_config: LoguruConfig
-    type_checking_mode: TypeCheckingMode
-
 
 class ApplicationConfigRepository(JsonConfigRepository[ApplicationConfig]):
     """

--- a/py_spring_core/core/application/py_spring_application.py
+++ b/py_spring_core/core/application/py_spring_application.py
@@ -14,7 +14,7 @@ from py_spring_core.commons.config_file_template_generator.config_file_template_
     ConfigFileTemplateGenerator,
 )
 from py_spring_core.commons.file_path_scanner import FilePathScanner
-from py_spring_core.core.application.application_config import ApplicationConfigRepository, TypeCheckingMode
+from py_spring_core.core.application.application_config import ApplicationConfigRepository
 from py_spring_core.core.application.context.application_context import (
     ApplicationContext,
 )

--- a/py_spring_core/core/entities/properties/properties_loader.py
+++ b/py_spring_core/core/entities/properties/properties_loader.py
@@ -1,5 +1,5 @@
 import json
-from typing import Callable, Optional, Type
+from typing import Any, Callable, Optional, Type
 
 import cachetools
 import yaml
@@ -32,7 +32,7 @@ class _PropertiesLoader:
         self.properties_classes = properties_classes
         self.properties_class_map = self._load_classes_as_map()
 
-        self.extension_loader_lookup:dict[str, Callable[[str], dict]] = {
+        self.extension_loader_lookup:dict[str, Callable[[str], dict[str, Any]]] = {
             "json": json.loads,
             "yaml": yaml.safe_load,
             "yml": yaml.safe_load,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "dnspython==2.6.1",
     "email-validator==2.2.0",
     "exceptiongroup==1.2.2",
-    "fastapi==0.112.0",
+    "fastapi==0.115.12",
     "fastapi-cli==0.0.5",
     "greenlet==3.0.3",
     "h11==0.14.0",
@@ -28,10 +28,6 @@ dependencies = [
     "MarkupSafe==2.1.5",
     "mdurl==0.1.2",
     "orjson==3.10.7",
-    "pydantic==2.8.2",
-    "pydantic-extra-types==2.9.0",
-    "pydantic-settings==2.4.0",
-    "pydantic-core==2.20.1",
     "Pygments==2.18.0",
     "python-dotenv==1.0.1",
     "python-multipart==0.0.9",
@@ -39,7 +35,7 @@ dependencies = [
     "rich==13.7.1",
     "shellingham==1.5.4",
     "sniffio==1.3.1",
-    "starlette==0.37.2",
+    "starlette<0.47.0,>=0.40.0",
     "typer>=0.12.5",
     "typing-extensions==4.12.2",
     "ujson==5.10.0",
@@ -48,7 +44,8 @@ dependencies = [
     "watchfiles==0.23.0",
     "websockets==12.0",
     "cachetools>=5.5.0",
-    "mypy>=1.11.2"
+    "mypy>=1.11.2",
+    "pydantic>=2.11.7"
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
# Dependency Updates and Configuration Cleanup

## Changes
- Updated FastAPI from 0.112.0 to 0.115.12
- Updated Starlette to version range `>=0.40.0,<0.47.0`
- Updated Pydantic to version `>=2.11.7`
- Removed explicit Pydantic-related package versions (pydantic, pydantic-extra-types, pydantic-settings, pydantic-core)
- Bumped package version from 0.0.7 to 0.0.8
- Removed `TypeCheckingMode` enum and related configuration from `ApplicationConfig`

## Technical Details
- Simplified dependency management by removing explicit Pydantic sub-package versions
- Removed unused type checking configuration to streamline the application config
- Updated type hints in `PropertiesLoader` to use more specific typing (`dict[str, Any]`)

## Testing
- [x] Verify FastAPI functionality with new version
- [X] Test application startup with updated dependencies
## Breaking Changes
None. This is a dependency update and configuration cleanup that maintains backward compatibility.