### PR TITLE
chore: Update version to 0.0.13 and refactor entity provider handling

### DIFF
--- a/py_spring_core/__init__.py
+++ b/py_spring_core/__init__.py
@@ -11,8 +11,9 @@ from py_spring_core.core.entities.controllers.route_mapping import (
 )
 from py_spring_core.core.entities.entity_provider import EntityProvider
 from py_spring_core.core.entities.properties.properties import Properties
+from py_spring_core.core.interfaces.application_context_required import ApplicationContextRequired
 from py_spring_core.event.application_event_publisher import ApplicationEventPublisher
 from py_spring_core.event.commons import ApplicationEvent
 from py_spring_core.event.application_event_handler_registry import EventListener
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -207,18 +207,6 @@ class ApplicationContext:
         bean_name = bean_cls.get_name()
         self.bean_collection_cls_container[bean_name] = bean_cls
 
-    def register_entity_provider(self, provider: EntityProvider) -> None:
-        self.providers.append(provider)
-        for entity_cls in provider.get_entities():
-            if issubclass(entity_cls, Component):
-                self.register_component(entity_cls)
-            elif issubclass(entity_cls, RestController):
-                self.register_controller(entity_cls)
-            elif issubclass(entity_cls, BeanCollection):
-                self.register_bean_collection(entity_cls)
-            elif issubclass(entity_cls, Properties):
-                self.register_properties(entity_cls)
-
     def register_properties(self, properties_cls: Type[Properties]) -> None:
         if not issubclass(properties_cls, Properties):
             raise TypeError(

--- a/py_spring_core/core/application/py_spring_application.py
+++ b/py_spring_core/core/application/py_spring_application.py
@@ -123,12 +123,12 @@ class PySpringApplication:
                     continue
                 handler(_cls)
 
-    def _register_entity_providers(
-        self, entity_providers: Iterable[EntityProvider]
-    ) -> None:
+    def _get_all_entities_from_entity_providers(self, entity_providers: Iterable[EntityProvider]) -> Iterable[Type[AppEntities]]:
+        entities: list[Type[AppEntities]] = []
         for provider in entity_providers:
-            self.app_context.register_entity_provider(provider)
-            provider.set_context(self.app_context)
+            entities.extend(provider.get_entities())
+
+        return entities
 
     def _handle_register_component(self, _cls: Type[Component]) -> None:
         self.app_context.register_component(_cls)
@@ -165,13 +165,19 @@ class PySpringApplication:
                 continue
             cls.set_application_context(self.app_context)
 
-    def __init_app(self) -> None:
+    def _prepare_injected_classes(self) -> Iterable[Type[object]]:
         scanned_classes = self._scan_classes_for_project()
         system_managed_classes = self._get_system_managed_classes()
-        classes_to_inject = [*scanned_classes, *system_managed_classes]
+        provider_entities = self._get_all_entities_from_entity_providers(self.entity_providers)
+        provider_classes = [provider.__class__ for provider in self.entity_providers]
+        # providers typically requires app context, so add to classess to inject
+        classes_to_inject = [*scanned_classes, *system_managed_classes, *provider_entities, *provider_classes]
+        return classes_to_inject
+
+    def __init_app(self) -> None:
+        classes_to_inject = self._prepare_injected_classes()
         self._inject_application_context_to_context_required(classes_to_inject)
         self._register_app_entities(classes_to_inject)
-        self._register_entity_providers(self.entity_providers)
         self.app_context.load_properties()
         self.app_context.init_ioc_container()
         self.app_context.inject_dependencies_for_app_entities()
@@ -196,10 +202,9 @@ class PySpringApplication:
         controllers = self.app_context.get_controller_instances()
         for controller in controllers:
             name = controller.__class__.__name__
-            routes = RouteMapping.routes.get(name, None)
-            if routes is None:
-                continue
-            controller._register_routes(routes)
+            routes = RouteMapping.routes.get(name, set())        
+            controller.post_construct()
+            controller._register_decorated_routes(routes)
             router = controller.get_router()
             self.fastapi.include_router(router)
             controller.register_middlewares()

--- a/py_spring_core/core/entities/controllers/rest_controller.py
+++ b/py_spring_core/core/entities/controllers/rest_controller.py
@@ -24,7 +24,9 @@ class RestController:
     class Config:
         prefix: str = ""
 
-    def _register_routes(self, routes: Iterable[RouteRegistration]) -> None:
+    def post_construct(self) -> None: ...
+
+    def _register_decorated_routes(self, routes: Iterable[RouteRegistration]) -> None:
         for route in routes:
             bound_method = partial(route.func, self)
             self.router.add_api_route(

--- a/py_spring_core/core/entities/entity_provider.py
+++ b/py_spring_core/core/entities/entity_provider.py
@@ -25,7 +25,7 @@ class EntityProvider:
     extneral_dependencies: list[Any] = field(default_factory=list)
     app_context: Optional["ApplicationContext"] = None
 
-    def get_entities(self) -> list[Type[object]]:
+    def get_entities(self) -> list[Type[AppEntities]]:
         return [
             *self.component_classes,
             *self.bean_collection_classes,

--- a/tests/test_entity_provider.py
+++ b/tests/test_entity_provider.py
@@ -24,7 +24,7 @@ class TestEntityProvider:
         self, test_entity_provider: EntityProvider
     ) -> ApplicationContext:
         app_context = ApplicationContext(ApplicationContextConfig(properties_path=""))
-        app_context.register_entity_provider(test_entity_provider)
+        app_context.providers.append(test_entity_provider)
         return app_context
 
     def test_did_raise_error_when_no_depends_on_is_provided(


### PR DESCRIPTION
- Changed version from 0.0.12 to 0.0.13.
- Refactored entity provider registration and entity retrieval in `PySpringApplication`.
- Introduced `_get_all_entities_from_entity_providers` method to streamline entity collection.
- Updated `ApplicationContext` to remove direct entity provider registration.
- Enhanced `RestController` with a new `post_construct` method for improved route registration.