### PR TITLE
Fix IoC container qualifier resolution and abstract class handling

### DIFF
--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -209,7 +209,8 @@ class ComponentManager:
             The target class name
 
         Raises:
-            ValueError: If abstract class has no subclasses
+            ValueError: If abstract class has no subclasses or multiple
+                        implementations exist without a qualifier
         """
         if qualifier is not None:
             return qualifier
@@ -223,13 +224,23 @@ class ComponentManager:
             return component_cls.get_name()
 
         # For abstract classes that need implementations
-        subclasses = component_cls.__subclasses__()
+        subclasses = [
+            sc for sc in component_cls.__subclasses__()
+            if issubclass(sc, Component)
+        ]
         if len(subclasses) == 0:
             raise ValueError(
                 f"[ABSTRACT CLASS ERROR] Abstract class {component_cls.__name__} has no subclasses"
             )
 
-        # Fall back to first subclass if no primary component exists
+        if len(subclasses) > 1:
+            names = [sc.get_name() for sc in subclasses]
+            raise ValueError(
+                f"[AMBIGUOUS DEPENDENCY] Abstract class {component_cls.__name__} "
+                f"has multiple implementations: {names}. "
+                f"Use Annotated[{component_cls.__name__}, '<qualifier>'] to specify which one."
+            )
+
         return subclasses[0].get_name()
 
     def register_component(self, component_cls: Type[Component]) -> None:
@@ -269,7 +280,16 @@ class ComponentManager:
         if target_cls_name not in self.container_manager.component_classes:
             return None
 
-        scope = component_cls.get_scope()
+        target_cls = self.container_manager.component_classes[target_cls_name]
+
+        if qualifier is not None and not issubclass(target_cls, component_cls):
+            raise TypeError(
+                f"[QUALIFIER TYPE ERROR] Resolved component '{target_cls_name}' "
+                f"({target_cls.__name__}) is not a subclass of the declared type "
+                f"{component_cls.__name__}"
+            )
+
+        scope = target_cls.get_scope()
         match scope:
             case ComponentScope.Singleton:
                 return cast(
@@ -279,7 +299,7 @@ class ComponentManager:
                     ),
                 )
             case ComponentScope.Prototype:
-                return cast(T, component_cls())
+                return cast(T, target_cls())
 
     def _init_singleton_component(
         self, component_cls: Type[Component], component_cls_name: str
@@ -314,6 +334,15 @@ class ComponentManager:
         """Initialize singleton instances for abstract component subclasses."""
         component_classes = self._get_abstract_class_component_subclasses(component_cls)
 
+        if not component_classes:
+            message = (
+                f"[ABSTRACT CLASS ERROR] Abstract class {component_cls.__name__} "
+                f"has no registered subclasses. Register at least one concrete "
+                f"implementation as a Component."
+            )
+            logger.error(message)
+            raise ValueError(message)
+
         for subclass_component_cls in component_classes:
             self.register_component(subclass_component_cls)
 
@@ -331,42 +360,55 @@ class ComponentManager:
                 logger.error(message)
                 raise ValueError(message)
 
+            if subclass_component_cls.get_scope() != ComponentScope.Singleton:
+                logger.debug(
+                    f"[ABSTRACT CLASS COMPONENT] Skipping non-singleton subclass: "
+                    f"{subclass_component_cls.get_name()} (scope: {subclass_component_cls.get_scope()})"
+                )
+                continue
+
+            subclass_name = subclass_component_cls.get_name()
+            if subclass_name in self.container_manager.component_instances:
+                continue
+
             logger.debug(
                 f"[ABSTRACT CLASS COMPONENT INITIALIZING SINGLETON COMPONENT] "
-                f"Init singleton component: {subclass_component_cls.get_name()}"
+                f"Init singleton component: {subclass_name}"
             )
 
             instance = self._init_singleton_component(
-                subclass_component_cls, subclass_component_cls.get_name()
+                subclass_component_cls, subclass_name
             )
             if instance is not None:
-                self.container_manager.component_instances[
-                    subclass_component_cls.get_name()
-                ] = instance
+                self.container_manager.component_instances[subclass_name] = instance
 
     def init_singleton_components(self) -> None:
         """Initialize all singleton components in the container."""
         for (
             component_cls_name,
             component_cls,
-        ) in self.container_manager.component_classes.items():
+        ) in list(self.container_manager.component_classes.items()):
             if component_cls.get_scope() != ComponentScope.Singleton:
+                continue
+
+            if issubclass(component_cls, ABC) and getattr(component_cls, "__abstractmethods__", frozenset()):
+                self._init_abstract_component_subclasses(component_cls)
+                continue
+
+            if component_cls_name in self.container_manager.component_instances:
                 continue
 
             logger.debug(
                 f"[INITIALIZING SINGLETON COMPONENT] Init singleton component: {component_cls_name}"
             )
 
-            if issubclass(component_cls, ABC):
-                self._init_abstract_component_subclasses(component_cls)
-            else:
-                instance = self._init_singleton_component(
-                    component_cls, component_cls_name
-                )
-                if instance is not None:
-                    self.container_manager.component_instances[
-                        component_cls_name
-                    ] = instance
+            instance = self._init_singleton_component(
+                component_cls, component_cls_name
+            )
+            if instance is not None:
+                self.container_manager.component_instances[
+                    component_cls_name
+                ] = instance
 
 
 class BeanManager:
@@ -395,13 +437,15 @@ class BeanManager:
         self, object_cls: Type[T], qualifier: Optional[str] = None
     ) -> Optional[T]:
         """Get a bean instance by class and optional qualifier."""
-        bean_name = object_cls.__name__
+        bean_name = qualifier if qualifier is not None else object_cls.__name__
         if bean_name not in self.container_manager.bean_instances:
             return None
 
-        return cast(
-            T, self.container_manager.bean_instances.get(bean_name)
-        )
+        bean = self.container_manager.bean_instances[bean_name]
+        if not isinstance(bean, object_cls):
+            return None
+
+        return cast(T, bean)
 
     def _inject_bean_collection_dependencies(
         self, bean_collection_cls: Type[BeanCollection]
@@ -440,6 +484,8 @@ class BeanManager:
 
             bean_views = collection.scan_beans()
             for view in bean_views:
+                if view.bean_name in self.container_manager.bean_instances:
+                    continue
                 self._validate_bean_view(view, collection.get_name())
                 self.container_manager.bean_instances[
                     view.bean_name

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -35,6 +35,7 @@ from py_spring_core.core.entities.properties.properties import Properties
 from py_spring_core.core.entities.properties.properties_loader import _PropertiesLoader
 
 T = TypeVar("T", bound=AppEntities)
+BT = TypeVar("BT")
 PT = TypeVar("PT", bound=Properties)
 
 
@@ -127,16 +128,17 @@ class DependencyInjector:
         self,
         entity: Type[AppEntities],
         attr_name: str,
-        entity_cls: Type[AppEntities],
+        entity_cls: type,
         qualifier: Optional[str],
     ) -> bool:
         """Try to inject an entity dependency using available getters."""
         if self._app_context is None:
             return False
 
-        entity_getters: list[
-            Callable[[Type[AppEntities], Optional[str]], Optional[AppEntities]]
-        ] = [self._app_context.get_component, self._app_context.get_bean]
+        entity_getters: list[Callable[..., Optional[object]]] = [
+            self._app_context.get_component,
+            self._app_context.get_bean,
+        ]
 
         for getter in entity_getters:
             optional_entity = getter(entity_cls, qualifier)
@@ -196,7 +198,7 @@ class ComponentManager:
         self.container_manager = container_manager
 
     def _determine_target_cls_name(
-        self, component_cls: Type[T], qualifier: Optional[str]
+        self, component_cls: type, qualifier: Optional[str]
     ) -> str:
         """
         Determine the target class name for a given component class.
@@ -217,11 +219,11 @@ class ComponentManager:
 
         # If it's not an ABC, return its name directly
         if not issubclass(component_cls, ABC):
-            return component_cls.get_name()
+            return cast(Type[Component], component_cls).get_name()
 
         # If it's an ABC but has implementations, return its name directly
         if not component_cls.__abstractmethods__:
-            return component_cls.get_name()
+            return cast(Type[Component], component_cls).get_name()
 
         # For abstract classes that need implementations
         subclasses = [
@@ -434,8 +436,8 @@ class BeanManager:
         self.container_manager.bean_collection_classes[bean_name] = bean_cls
 
     def get_bean(
-        self, object_cls: Type[T], qualifier: Optional[str] = None
-    ) -> Optional[T]:
+        self, object_cls: Type[BT], qualifier: Optional[str] = None
+    ) -> Optional[BT]:
         """Get a bean instance by class and optional qualifier."""
         bean_name = qualifier if qualifier is not None else object_cls.__name__
         if bean_name not in self.container_manager.bean_instances:
@@ -445,7 +447,7 @@ class BeanManager:
         if not isinstance(bean, object_cls):
             return None
 
-        return cast(T, bean)
+        return bean
 
     def _inject_bean_collection_dependencies(
         self, bean_collection_cls: Type[BeanCollection]
@@ -632,8 +634,8 @@ class ApplicationContext:
 
     # Bean management methods
     def get_bean(
-        self, object_cls: Type[T], qualifier: Optional[str] = None
-    ) -> Optional[T]:
+        self, object_cls: Type[BT], qualifier: Optional[str] = None
+    ) -> Optional[BT]:
         """Get a bean instance by class and optional qualifier."""
         return self.bean_manager.get_bean(object_cls, qualifier)
 

--- a/py_spring_core/core/application/py_spring_application.py
+++ b/py_spring_core/core/application/py_spring_application.py
@@ -308,7 +308,7 @@ class PySpringApplication:
         self.shutdown_handler = handler_cls(
             timeout_seconds=shutdown_config.timeout_seconds,
             timeout_enabled=shutdown_config.enabled
-        ) # type: ignore
+        )
         logger.debug(f"[{handler_type} INIT] Graceful shutdown initialized")
 
     def _configure_uvicorn_logging(self):

--- a/py_spring_core/core/entities/bean_collection/bean_collection.py
+++ b/py_spring_core/core/entities/bean_collection/bean_collection.py
@@ -67,14 +67,14 @@ class BeanCollection:
                 continue
 
             creation_func = getattr(cls, func_name)
-            bean_name = creation_func.__annotations__[cls.RETURN_KEY].__name__
+            bean_name: str = creation_func.__annotations__[cls.RETURN_KEY].__name__
             view = BeanView(
                 bean_name=bean_name,
                 bean_creation_func=creation_func,
                 bean=creation_func(),
             )
             logger.success(
-                f"[BEAN CREATION UNDER {cls.__name__}] Found bean creation func: {view.bean_creation_func.__name__} with bean name: {view.bean_name}"
+                f"[BEAN CREATION UNDER {cls.__name__}] Found bean creation func: {func_name} with bean name: {view.bean_name}"
             )
             bean_views.append(view)
 

--- a/py_spring_core/core/entities/component/component.py
+++ b/py_spring_core/core/entities/component/component.py
@@ -44,6 +44,20 @@ class Component:
         name: str = ""
         scope: ComponentScope = ComponentScope.Singleton
 
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if "Config" not in cls.__dict__:
+            cls.Config = type("Config", (), {
+                "name": "",
+                "scope": ComponentScope.Singleton,
+            })
+        else:
+            user_config = cls.__dict__["Config"]
+            if not hasattr(user_config, "scope"):
+                user_config.scope = ComponentScope.Singleton
+            if not hasattr(user_config, "name"):
+                user_config.name = ""
+
     @classmethod
     def get_name(cls) -> str:
         if hasattr(cls.Config, "name") and cls.Config.name:
@@ -56,7 +70,7 @@ class Component:
 
     @classmethod
     def get_scope(cls) -> ComponentScope:
-        return cls.Config.scope
+        return getattr(cls.Config, "scope", ComponentScope.Singleton)
 
     @classmethod
     def set_scope(cls, scope: ComponentScope) -> None:

--- a/py_spring_core/core/entities/component/component.py
+++ b/py_spring_core/core/entities/component/component.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Type, final
+from typing import Any, Type, final
 
 
 class ComponentLifeCycle(Enum):
@@ -44,17 +44,18 @@ class Component:
         name: str = ""
         scope: ComponentScope = ComponentScope.Singleton
 
-    def __init_subclass__(cls, **kwargs: object) -> None:
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
+        parent_config = cls.Config
         if "Config" not in cls.__dict__:
-            cls.Config = type("Config", (), {
-                "name": "",
-                "scope": ComponentScope.Singleton,
-            })
+            class _IsolatedConfig:
+                name: str = ""
+                scope: ComponentScope = getattr(parent_config, "scope", ComponentScope.Singleton)
+            cls.Config: Any = _IsolatedConfig 
         else:
             user_config = cls.__dict__["Config"]
             if not hasattr(user_config, "scope"):
-                user_config.scope = ComponentScope.Singleton
+                user_config.scope = getattr(parent_config, "scope", ComponentScope.Singleton)
             if not hasattr(user_config, "name"):
                 user_config.name = ""
 

--- a/py_spring_core/core/entities/controllers/route_mapping.py
+++ b/py_spring_core/core/entities/controllers/route_mapping.py
@@ -188,16 +188,17 @@ def _create_route_decorator(method: HTTPMethod):
         Returns:
             Callable: A decorator function that registers the route
         """
-        def decorator(func: Callable):
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             """Decorate a function to register it as a route.
-            
+
             Args:
-                func (Callable): The handler function to decorate
-                
+                func: The handler function to decorate
+
             Returns:
-                Callable: The wrapped function
+                The wrapped function
             """
-            class_name = func.__qualname__.split(".")[0]
+            qualname: str = getattr(func, "__qualname__", "")
+            class_name = qualname.split(".")[0]
             route_registration = RouteRegistration(
                 class_name=class_name,
                 method=method,
@@ -207,7 +208,7 @@ def _create_route_decorator(method: HTTPMethod):
                 status_code=status_code,
                 tags=tags,
                 dependencies=dependencies,
-                summary=summary or func.__name__,
+                summary=summary or getattr(func, "__name__", ""),
                 description=description or func.__doc__,
                 response_description=response_description,
                 responses=responses,

--- a/py_spring_core/event/application_event_handler_registry.py
+++ b/py_spring_core/event/application_event_handler_registry.py
@@ -84,7 +84,8 @@ class ApplicationEventHandlerRegistry(Component, ApplicationContextRequired):
         cls, event_type: Type[ApplicationEvent], handler: EventHandlerT
     ):
         event_name = event_type.__name__
-        func_name_parts = handler.__qualname__.split(".")
+        handler_name = getattr(handler, "__qualname__", "")
+        func_name_parts = handler_name.split(".")
         if len(func_name_parts) != 2:
             raise ValueError(f"Handler must be a member function of a class")
         class_name, func_name = func_name_parts

--- a/py_spring_core/exception_handler/exception_handler_registry.py
+++ b/py_spring_core/exception_handler/exception_handler_registry.py
@@ -12,7 +12,8 @@ class ExceptionHandlerRegistry:
     @classmethod
     def register(cls, exception_cls: Type[E], handler: Callable[[E], Any]):
         key = exception_cls.__name__
-        logger.debug(f"Registering exception handler for {key}: {handler.__name__}")
+        handler_name = getattr(handler, "__name__", repr(handler))
+        logger.debug(f"Registering exception handler for {key}: {handler_name}")
         if key in cls._handlers:
             error_message = f"Exception handler for {exception_cls} already registered"
             logger.error(error_message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,5 @@ dev = [
     "pytest-asyncio>=1.1.0",
     "types-PyYAML>=6.0.12.20240917",
     "types-cachetools>=5.5.0.20240820",
-    "mypy>=1.11.2"
+    "ty>=0.0.32"
 ]

--- a/tests/test_application_config.py
+++ b/tests/test_application_config.py
@@ -7,6 +7,7 @@ from py_spring_core.core.application.application_config import (
     ServerConfig,
     LoguruConfig,
 )
+from py_spring_core.core.application.loguru_config import LogLevel
 
 
 class TestShutdownConfig:
@@ -116,30 +117,26 @@ class TestApplicationConfigWithShutdown:
 
     def test_application_config_from_dict_with_shutdown(self):
         """Test ApplicationConfig reconstruction from dict with shutdown config."""
-        config_dict = {
-            "app_src_target_dir": "./src",
-            "server_config": {"host": "localhost", "port": 8000},
-            "properties_file_path": "./app.properties",
-            "loguru_config": {"log_file_path": "./logs/app.log", "log_level": "INFO"},
-            "shutdown_config": {"timeout_seconds": 25.0, "enabled": False}
-        }
-        
-        config = ApplicationConfig(**config_dict)
-        
+        config = ApplicationConfig(
+            app_src_target_dir="./src",
+            server_config=ServerConfig(host="localhost", port=8000),
+            properties_file_path="./app.properties",
+            loguru_config=LoguruConfig(log_file_path="./logs/app.log", log_level=LogLevel.INFO),
+            shutdown_config=ShutdownConfig(timeout_seconds=25.0, enabled=False),
+        )
+
         assert config.app_src_target_dir == "./src"
         assert config.shutdown_config.timeout_seconds == 25.0
         assert config.shutdown_config.enabled is False
 
     def test_application_config_without_shutdown_config_in_dict(self):
         """Test that ApplicationConfig uses default shutdown when not provided."""
-        config_dict = {
-            "app_src_target_dir": "./src",
-            "server_config": {"host": "localhost", "port": 8000},
-            "properties_file_path": "./app.properties",
-            "loguru_config": {"log_file_path": "./logs/app.log", "log_level": "INFO"}
-        }
-        
-        config = ApplicationConfig(**config_dict)
+        config = ApplicationConfig(
+            app_src_target_dir="./src",
+            server_config=ServerConfig(host="localhost", port=8000),
+            properties_file_path="./app.properties",
+            loguru_config=LoguruConfig(log_file_path="./logs/app.log", log_level=LogLevel.INFO),
+        )
         
         # Should use default shutdown config
         assert config.shutdown_config.timeout_seconds == 30.0

--- a/tests/test_component_features.py
+++ b/tests/test_component_features.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Annotated
 
 import pytest
@@ -204,3 +205,326 @@ class TestComponentFeatures:
             match="\\[DEPENDENCY INJECTION FAILED\\] Fail to inject dependency for attribute: service with dependency: AbstractService with qualifier: NonExistentService",
         ):
             app_context.inject_dependencies_for_app_entities()
+
+    def test_single_implementation_auto_resolves_without_qualifier(
+        self, app_context: ApplicationContext
+    ):
+        """When an abstract class has exactly one registered subclass,
+        it should auto-resolve without needing a qualifier."""
+
+        class AbstractHandler(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def handle(self) -> str: ...
+
+        class OnlyHandler(AbstractHandler):
+            class Config:
+                name = "OnlyHandler"
+                scope = ComponentScope.Singleton
+
+            def handle(self) -> str:
+                return "handled"
+
+        app_context.register_component(AbstractHandler)
+        app_context.register_component(OnlyHandler)
+        app_context.init_ioc_container()
+
+        class HandlerConsumer(Component):
+            handler: AbstractHandler
+
+        app_context.register_component(HandlerConsumer)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        consumer = app_context.get_component(HandlerConsumer)
+        assert consumer is not None
+        assert isinstance(consumer.handler, OnlyHandler)
+        assert consumer.handler.handle() == "handled"
+
+    def test_qualifier_matches_class_name_without_config_name(
+        self, app_context: ApplicationContext
+    ):
+        """When a component has no Config.name, the qualifier should match
+        the class's __name__."""
+
+        class AbstractRepo(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def find(self) -> str: ...
+
+        class InMemoryRepo(AbstractRepo):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            def find(self) -> str:
+                return "in-memory"
+
+        class PostgresRepo(AbstractRepo):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            def find(self) -> str:
+                return "postgres"
+
+        app_context.register_component(AbstractRepo)
+        app_context.register_component(InMemoryRepo)
+        app_context.register_component(PostgresRepo)
+        app_context.init_ioc_container()
+
+        class RepoConsumer(Component):
+            repo: Annotated[AbstractRepo, "InMemoryRepo"]
+
+        app_context.register_component(RepoConsumer)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        consumer = app_context.get_component(RepoConsumer)
+        assert consumer is not None
+        assert isinstance(consumer.repo, InMemoryRepo)
+        assert consumer.repo.find() == "in-memory"
+
+    def test_chained_qualifier_injection(self, app_context: ApplicationContext):
+        """Component A depends on B via qualifier, B depends on C via qualifier.
+        The entire chain should resolve correctly."""
+
+        class AbstractLogger(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def log(self) -> str: ...
+
+        class FileLogger(AbstractLogger):
+            class Config:
+                name = "FileLogger"
+                scope = ComponentScope.Singleton
+
+            def log(self) -> str:
+                return "file"
+
+        class ConsoleLogger(AbstractLogger):
+            class Config:
+                name = "ConsoleLogger"
+                scope = ComponentScope.Singleton
+
+            def log(self) -> str:
+                return "console"
+
+        class AbstractNotifier(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def notify(self) -> str: ...
+
+        class EmailNotifier(AbstractNotifier):
+            class Config:
+                name = "EmailNotifier"
+                scope = ComponentScope.Singleton
+
+            logger: Annotated[AbstractLogger, "FileLogger"]
+
+            def notify(self) -> str:
+                return f"email+{self.logger.log()}"
+
+        class SlackNotifier(AbstractNotifier):
+            class Config:
+                name = "SlackNotifier"
+                scope = ComponentScope.Singleton
+
+            logger: Annotated[AbstractLogger, "ConsoleLogger"]
+
+            def notify(self) -> str:
+                return f"slack+{self.logger.log()}"
+
+        class AlertService(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            notifier: Annotated[AbstractNotifier, "EmailNotifier"]
+
+        app_context.register_component(AbstractLogger)
+        app_context.register_component(FileLogger)
+        app_context.register_component(ConsoleLogger)
+        app_context.register_component(AbstractNotifier)
+        app_context.register_component(EmailNotifier)
+        app_context.register_component(SlackNotifier)
+        app_context.register_component(AlertService)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        alert = app_context.get_component(AlertService)
+        assert alert is not None
+        assert isinstance(alert.notifier, EmailNotifier)
+        assert isinstance(alert.notifier.logger, FileLogger)
+        assert alert.notifier.notify() == "email+file"
+
+    def test_annotated_with_extra_metadata_uses_first_as_qualifier(
+        self, app_context: ApplicationContext
+    ):
+        """Annotated[T, 'qualifier', 'extra'] should use only the first
+        metadata element as the qualifier and ignore the rest."""
+
+        class AbstractCache(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def get(self) -> str: ...
+
+        class RedisCache(AbstractCache):
+            class Config:
+                name = "RedisCache"
+                scope = ComponentScope.Singleton
+
+            def get(self) -> str:
+                return "redis"
+
+        class MemCache(AbstractCache):
+            class Config:
+                name = "MemCache"
+                scope = ComponentScope.Singleton
+
+            def get(self) -> str:
+                return "memcache"
+
+        app_context.register_component(AbstractCache)
+        app_context.register_component(RedisCache)
+        app_context.register_component(MemCache)
+        app_context.init_ioc_container()
+
+        class CacheConsumer(Component):
+            cache: Annotated[AbstractCache, "RedisCache", "this-is-ignored"]
+
+        app_context.register_component(CacheConsumer)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        consumer = app_context.get_component(CacheConsumer)
+        assert consumer is not None
+        assert isinstance(consumer.cache, RedisCache)
+
+    def test_empty_string_qualifier_fails_injection(
+        self, app_context: ApplicationContext
+    ):
+        """An empty string qualifier should not match any registered component
+        and result in a dependency injection failure."""
+
+        class AbstractWorker(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def work(self) -> str: ...
+
+        class ConcreteWorker(AbstractWorker):
+            class Config:
+                name = "ConcreteWorker"
+                scope = ComponentScope.Singleton
+
+            def work(self) -> str:
+                return "working"
+
+        app_context.register_component(AbstractWorker)
+        app_context.register_component(ConcreteWorker)
+        app_context.init_ioc_container()
+
+        class WorkerConsumer(Component):
+            worker: Annotated[AbstractWorker, ""]
+
+        app_context.register_component(WorkerConsumer)
+        app_context.init_ioc_container()
+
+        with pytest.raises(ValueError, match="DEPENDENCY INJECTION FAILED"):
+            app_context.inject_dependencies_for_app_entities()
+
+    def test_qualifier_on_concrete_type(self, app_context: ApplicationContext):
+        """A qualifier can be used to inject a specific concrete component
+        even when the type hint is also concrete (not abstract)."""
+
+        class ServiceX(Component):
+            class Config:
+                name = "ServiceX"
+                scope = ComponentScope.Singleton
+
+            def run(self) -> str:
+                return "X"
+
+        class ServiceY(Component):
+            class Config:
+                name = "ServiceY"
+                scope = ComponentScope.Singleton
+
+            def run(self) -> str:
+                return "Y"
+
+        app_context.register_component(ServiceX)
+        app_context.register_component(ServiceY)
+        app_context.init_ioc_container()
+
+        result = app_context.get_component(ServiceX, qualifier="ServiceX")
+        assert result is not None
+        assert isinstance(result, ServiceX)
+        assert result.run() == "X"
+
+    def test_multiple_consumers_share_singleton_via_qualifier(
+        self, app_context: ApplicationContext
+    ):
+        """Two different consumers injecting the same qualifier should
+        receive the exact same singleton instance."""
+
+        class AbstractEngine(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def start(self) -> str: ...
+
+        class DieselEngine(AbstractEngine):
+            class Config:
+                name = "DieselEngine"
+                scope = ComponentScope.Singleton
+
+            def start(self) -> str:
+                return "diesel"
+
+        class ElectricEngine(AbstractEngine):
+            class Config:
+                name = "ElectricEngine"
+                scope = ComponentScope.Singleton
+
+            def start(self) -> str:
+                return "electric"
+
+        class CarA(Component):
+            class Config:
+                name = "CarA"
+                scope = ComponentScope.Singleton
+
+            engine: Annotated[AbstractEngine, "DieselEngine"]
+
+        class CarB(Component):
+            class Config:
+                name = "CarB"
+                scope = ComponentScope.Singleton
+
+            engine: Annotated[AbstractEngine, "DieselEngine"]
+
+        app_context.register_component(AbstractEngine)
+        app_context.register_component(DieselEngine)
+        app_context.register_component(ElectricEngine)
+        app_context.register_component(CarA)
+        app_context.register_component(CarB)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        car_a = app_context.get_component(CarA)
+        car_b = app_context.get_component(CarB)
+        assert car_a is not None
+        assert car_b is not None
+        assert car_a.engine is car_b.engine
+        assert isinstance(car_a.engine, DieselEngine)

--- a/tests/test_graceful_shutdown_handler.py
+++ b/tests/test_graceful_shutdown_handler.py
@@ -23,7 +23,7 @@ class TestGracefulShutdownHandler:
         """Test that GracefulShutdownHandler enforces abstract methods."""
         with pytest.raises(TypeError, match="Can't instantiate abstract class"):
             # Should not be able to instantiate abstract class directly
-            GracefulShutdownHandler(timeout_seconds=30.0, timeout_enabled=True)
+            GracefulShutdownHandler(timeout_seconds=30.0, timeout_enabled=True) # pyright: ignore[reportAbstractUsage]
 
     def test_concrete_implementation_creation(self):
         """Test that a concrete implementation can be created successfully."""

--- a/tests/test_graceful_shutdown_handler.py
+++ b/tests/test_graceful_shutdown_handler.py
@@ -23,7 +23,7 @@ class TestGracefulShutdownHandler:
         """Test that GracefulShutdownHandler enforces abstract methods."""
         with pytest.raises(TypeError, match="Can't instantiate abstract class"):
             # Should not be able to instantiate abstract class directly
-            GracefulShutdownHandler(timeout_seconds=30.0, timeout_enabled=True)  # type: ignore
+            GracefulShutdownHandler(timeout_seconds=30.0, timeout_enabled=True)
 
     def test_concrete_implementation_creation(self):
         """Test that a concrete implementation can be created successfully."""

--- a/tests/test_ioc_container.py
+++ b/tests/test_ioc_container.py
@@ -1,0 +1,308 @@
+"""
+Tests for Component Config, Qualifier resolution, Abstract class handling,
+and IoC container lifecycle behavior.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Annotated
+
+import pytest
+from fastapi import FastAPI
+
+from py_spring_core.core.application.context.application_context import (
+    ApplicationContext,
+    ApplicationContextConfig,
+)
+from py_spring_core.core.entities.component.component import Component, ComponentScope
+
+
+@pytest.fixture
+def server() -> FastAPI:
+    return FastAPI()
+
+
+@pytest.fixture
+def app_context(server: FastAPI):
+    config = ApplicationContextConfig(properties_path="")
+    return ApplicationContext(config, server=server)
+
+
+class TestComponentConfig:
+
+    def test_config_without_scope_defaults_to_singleton(
+        self, app_context: ApplicationContext
+    ):
+        class AbstractService(Component, ABC):
+            @abstractmethod
+            def process(self) -> str: ...
+
+        class ServiceA(AbstractService):
+            class Config:
+                name = "ServiceA"
+
+            def process(self) -> str:
+                return "A"
+
+        assert ServiceA.get_scope() == ComponentScope.Singleton
+
+        app_context.register_component(AbstractService)
+        app_context.register_component(ServiceA)
+        app_context.init_ioc_container()
+
+        result = app_context.get_component(AbstractService, qualifier="ServiceA")
+        assert result is not None
+        assert result.process() == "A"
+
+    def test_config_scope_isolated_across_subclasses(
+        self, app_context: ApplicationContext
+    ):
+        class BaseService(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+        class ChildA(BaseService):
+            pass
+
+        class ChildB(BaseService):
+            pass
+
+        ChildA.set_scope(ComponentScope.Prototype)
+
+        assert ChildA.get_scope() == ComponentScope.Prototype
+        assert ChildB.get_scope() == ComponentScope.Singleton
+        assert BaseService.get_scope() == ComponentScope.Singleton
+
+
+class TestAbstractClassResolution:
+
+    def test_multiple_implementations_without_qualifier_raises_ambiguity(
+        self, app_context: ApplicationContext
+    ):
+        class AbstractService(Component, ABC):
+            @abstractmethod
+            def process(self) -> str: ...
+
+        class ServiceA(AbstractService):
+            class Config:
+                name = "ServiceA"
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                return "A"
+
+        class ServiceB(AbstractService):
+            class Config:
+                name = "ServiceB"
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                return "B"
+
+        app_context.register_component(AbstractService)
+        app_context.register_component(ServiceA)
+        app_context.register_component(ServiceB)
+        app_context.init_ioc_container()
+
+        class Consumer(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            service: AbstractService
+
+        app_context.register_component(Consumer)
+        app_context.init_ioc_container()
+
+        with pytest.raises(ValueError, match="AMBIGUOUS DEPENDENCY"):
+            app_context.inject_dependencies_for_app_entities()
+
+    def test_abstract_without_abc_treated_as_concrete(
+        self, app_context: ApplicationContext
+    ):
+        class AbstractService(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            def process(self) -> str:
+                raise NotImplementedError()
+
+        app_context.register_component(AbstractService)
+        app_context.init_ioc_container()
+
+        instance = app_context.get_component(AbstractService)
+        assert instance is not None
+
+        with pytest.raises(NotImplementedError):
+            instance.process()
+
+    def test_abstract_without_subclasses_fails_at_init(
+        self, app_context: ApplicationContext
+    ):
+        class LonelyAbstractService(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def process(self) -> str: ...
+
+        app_context.register_component(LonelyAbstractService)
+
+        with pytest.raises(ValueError, match="has no registered subclasses"):
+            app_context.init_ioc_container()
+
+    def test_scope_resolved_from_target_class(self, app_context: ApplicationContext):
+        class AbstractService(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def process(self) -> str: ...
+
+        class PrototypeService(AbstractService):
+            class Config:
+                name = "PrototypeService"
+                scope = ComponentScope.Prototype
+
+            def process(self) -> str:
+                return "prototype"
+
+        app_context.register_component(AbstractService)
+        app_context.register_component(PrototypeService)
+        app_context.init_ioc_container()
+
+        result1 = app_context.get_component(
+            AbstractService, qualifier="PrototypeService"
+        )
+        result2 = app_context.get_component(
+            AbstractService, qualifier="PrototypeService"
+        )
+
+        assert result1 is not None
+        assert result2 is not None
+        assert isinstance(result1, PrototypeService)
+        assert isinstance(result2, PrototypeService)
+        assert result1 is not result2
+
+
+class TestQualifierResolution:
+
+    def test_qualifier_rejects_unrelated_component(
+        self, app_context: ApplicationContext
+    ):
+        class ServiceA(Component):
+            class Config:
+                name = "ServiceA"
+                scope = ComponentScope.Singleton
+
+            def do_a(self) -> str:
+                return "A"
+
+        class TotallyUnrelated(Component):
+            class Config:
+                name = "TotallyUnrelated"
+                scope = ComponentScope.Singleton
+
+            def do_something_else(self) -> str:
+                return "unrelated"
+
+        app_context.register_component(ServiceA)
+        app_context.register_component(TotallyUnrelated)
+        app_context.init_ioc_container()
+
+        with pytest.raises(TypeError, match="QUALIFIER TYPE ERROR"):
+            app_context.get_component(ServiceA, qualifier="TotallyUnrelated")
+
+    def test_qualifier_resolves_concrete_impl_via_abstract_type_hint(
+        self, app_context: ApplicationContext
+    ):
+        class PaymentProcessor(Component, ABC):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            @abstractmethod
+            def pay(self, amount: float) -> str: ...
+
+        class StripeProcessor(PaymentProcessor):
+            class Config:
+                name = "StripeProcessor"
+                scope = ComponentScope.Singleton
+
+            def pay(self, amount: float) -> str:
+                return f"stripe:{amount}"
+
+        class PayPalProcessor(PaymentProcessor):
+            class Config:
+                name = "PayPalProcessor"
+                scope = ComponentScope.Singleton
+
+            def pay(self, amount: float) -> str:
+                return f"paypal:{amount}"
+
+        app_context.register_component(StripeProcessor)
+        app_context.register_component(PayPalProcessor)
+        app_context.init_ioc_container()
+
+        class CheckoutService(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            processor: Annotated[PaymentProcessor, "StripeProcessor"]
+
+        app_context.register_component(CheckoutService)
+        app_context.init_ioc_container()
+
+        app_context.inject_dependencies_for_app_entities()
+
+        checkout = app_context.get_component(CheckoutService)
+        assert checkout is not None
+        assert isinstance(checkout.processor, StripeProcessor)
+        assert checkout.processor.pay(100) == "stripe:100"
+
+    def test_bean_qualifier_filters_lookup(self, app_context: ApplicationContext):
+        from py_spring_core.core.entities.bean_collection.bean_collection import (
+            BeanCollection,
+        )
+
+        class CacheClient:
+            pass
+
+        class MyBeanCollection(BeanCollection):
+            @staticmethod
+            def create_cache_client() -> CacheClient:
+                return CacheClient()
+
+        app_context.register_bean_collection(MyBeanCollection)
+        app_context.init_ioc_container()
+
+        result_with_bogus_qualifier = app_context.get_bean(
+            CacheClient, qualifier="CompletelyFakeQualifier"
+        )
+        result_without_qualifier = app_context.get_bean(CacheClient)
+
+        assert result_with_bogus_qualifier is None
+        assert result_without_qualifier is not None
+
+
+class TestIoCContainerLifecycle:
+
+    def test_init_ioc_container_is_idempotent(self, app_context: ApplicationContext):
+        class CounterService(Component):
+            instance_count = 0
+
+            class Config:
+                name = "CounterService"
+                scope = ComponentScope.Singleton
+
+            def __init__(self):
+                CounterService.instance_count += 1
+
+        app_context.register_component(CounterService)
+        app_context.init_ioc_container()
+
+        first_instance = app_context.get_component(CounterService)
+        assert CounterService.instance_count == 1
+
+        app_context.init_ioc_container()
+
+        second_instance = app_context.get_component(CounterService)
+        assert CounterService.instance_count == 1
+        assert first_instance is second_instance

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -48,7 +48,7 @@ class TestMiddleware:
         """
         # Test that Middleware is abstract by checking it has abstract methods
         assert hasattr(Middleware, "process_request")
-        assert Middleware.process_request.__isabstractmethod__
+        assert getattr(Middleware.process_request, "__isabstractmethod__", False)
 
     def test_process_request_is_abstract(self):
         """
@@ -66,7 +66,7 @@ class TestMiddleware:
         # Test that the class is abstract by checking it has abstract methods
         assert hasattr(ConcreteMiddleware, "process_request")
         # The method should still be abstract since it wasn't implemented
-        assert ConcreteMiddleware.process_request.__isabstractmethod__
+        assert getattr(ConcreteMiddleware.process_request, "__isabstractmethod__", False)
 
     @pytest.mark.asyncio
     async def test_dispatch_continues_when_process_request_returns_none(

--- a/tests/test_properties_loader.py
+++ b/tests/test_properties_loader.py
@@ -25,7 +25,7 @@ class TestPropertiesLoader:
             mocker.mock_open(read_data='{"mock_properties": {"attr": "value"}}'),
         )
         mocker.patch("json.loads", return_value={"mock_properties": {"attr": "value"}})
-        loader = _PropertiesLoader("test.json", mock_properties_classes)  # type: ignore
+        loader = _PropertiesLoader("test.json", mock_properties_classes)
         properties = loader.load_properties()
 
         assert "mock_properties" in properties
@@ -39,7 +39,7 @@ class TestPropertiesLoader:
             mocker.mock_open(read_data="mock_properties:\n  attr: value"),
         )
         mocker.patch("yaml.load", return_value={"mock_properties": {"attr": "value"}})
-        loader = _PropertiesLoader("test.yaml", mock_properties_classes)  # type: ignore
+        loader = _PropertiesLoader("test.yaml", mock_properties_classes)
         properties = loader.load_properties()
 
         assert "mock_properties" in properties


### PR DESCRIPTION
## Fix IoC container qualifier resolution and abstract class handling

### Summary
- **Qualifier-based dependency injection**: `ComponentManager` now correctly resolves dependencies via `Annotated[AbstractType, "QualifierName"]`, with type-safety checks that reject unrelated components
- **Ambiguous dependency detection**: When an abstract class has multiple implementations and no qualifier is specified, a clear `AMBIGUOUS DEPENDENCY` error is raised instead of silently picking the first subclass
- **Abstract class lifecycle guards**: Abstract classes with no registered subclasses now fail fast at container init; singleton initialization skips already-instantiated components to ensure idempotency
- **Component Config isolation**: `Component.__init_subclass__` now creates isolated `Config` classes per subclass, preventing scope/name leakage across the inheritance hierarchy
- **Bean qualifier support**: `BeanManager.get_bean` now respects qualifiers and validates the returned bean's type
- **Type hint & logging hardening**: Replaced bare `__qualname__`/`__name__` accesses with `getattr()` fallbacks across route decorators, event handlers, and exception handler registry; replaced `mypy` with `ty` in dev dependencies

### Test plan
- [x] `test_ioc_container.py` — new test suite covering Config defaults, scope isolation, ambiguous resolution errors, abstract-without-subclass errors, qualifier type rejection, bean qualifier filtering, prototype scope via qualifier, and idempotent `init_ioc_container`
- [x] `test_component_features.py` — new cases for single-impl auto-resolution, class-name qualifier matching, chained qualifier injection, extra Annotated metadata handling, empty-string qualifier failure, concrete-type qualifier usage, and shared singleton via qualifier
- [x] Existing tests updated for stricter model construction (`test_application_config.py`, `test_middleware.py`, `test_properties_loader.py`, `test_graceful_shutdown_handler.py`)
