### PR TITLE
Bump: Upgrade FastAPI dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 name: Running pytest
-on: [push, workflow_dispatch]
+on: [push, workflow_dispatch, pull_request]
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ dependencies = [
     "dnspython>=2.6.1",
     "email-validator>=2.2.0",
     "exceptiongroup>=1.2.2",
-    "fastapi>=0.115.12",
-    "fastapi-cli>=0.0.5",
+    "fastapi>=0.136.1",
     "greenlet>=3.0.3",
     "h11>=0.16.0",
     "httpcore>=1.0.9",
@@ -67,7 +66,7 @@ source-includes = [
     "scripts/",
 ]
 
-[tool.pdm.dev-dependencies]
+[dependency-groups]
 dev = [
     "ruff>=0.6.3",
     "isort>=5.13.2",


### PR DESCRIPTION
Update GitHub Actions workflow to trigger on pull requests; upgrade FastAPI dependency to version 0.136.1 and adjust dev-dependencies section.