### PR TITLE
Remove uvloop dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "typing-extensions>=4.12.2",
     "ujson>=5.10.0",
     "uvicorn>=0.30.5",
-    "uvloop>=0.19.0",
     "watchfiles>=0.23.0",
     "websockets>=12.0",
     "cachetools>=5.5.0",


### PR DESCRIPTION
Remove uvloop explicit dependency, uvicorn can take care of it if running platform is under windows
<img width="1052" height="515" alt="image" src="https://github.com/user-attachments/assets/9eb50cfe-dd41-46a9-8638-68a620bb58e3" />
