### PR TITLE
Refactor Global Mutable State into Instance-Owned ApplicationRegistry

### DIFF
--- a/py_spring_core/core/application/application_registry.py
+++ b/py_spring_core/core/application/application_registry.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, field
+from queue import Queue
+from typing import Any, Callable
+
+from py_spring_core.core.entities.controllers.route_mapping import RouteRegistration
+from py_spring_core.event.commons import ApplicationEvent
+
+
+@dataclass
+class ApplicationRegistry:
+    """
+    Owns all mutable state that was previously scattered across class variables.
+    One instance per PySpringApplication. Passed through ApplicationContext.
+    """
+
+    # Route registrations: class_name -> set of routes
+    routes: dict[str, set[RouteRegistration]] = field(default_factory=dict)
+
+    # Event handlers: event_name -> list of handler info
+    # Stored as dicts to avoid circular import with EventHandler
+    event_handlers: dict[str, list[Any]] = field(default_factory=dict)
+
+    # Exception handlers: exception_class_name -> handler callable
+    exception_handlers: dict[str, Callable] = field(default_factory=dict)
+
+    # Properties loaded from config files
+    loaded_properties: dict[str, Any] = field(default_factory=dict)
+
+    # Event message queue
+    event_queue: Queue[ApplicationEvent] = field(default_factory=Queue)
+
+    def clear(self) -> None:
+        """Reset all state. Useful for testing."""
+        self.routes.clear()
+        self.event_handlers.clear()
+        self.exception_handlers.clear()
+        self.loaded_properties.clear()
+        self.event_queue = Queue()

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -685,6 +685,19 @@ class ApplicationContext:
         """Get a component instance by class and optional qualifier."""
         return self.component_manager.get_component(component_cls, qualifier)
 
+    def must_get_component(
+        self, component_cls: Type[T], qualifier: Optional[str] = None
+    ) -> T:
+        """Get a component instance, raising if not found."""
+        result = self.get_component(component_cls, qualifier)
+        if result is None:
+            name = component_cls.__name__
+            msg = f"Component {name} not found"
+            if qualifier:
+                msg += f" with qualifier '{qualifier}'"
+            raise LookupError(msg)
+        return result
+
     def register_component(self, component_cls: Type[Component]) -> None:
         """Register a component class in the application context."""
         self.component_manager.register_component(component_cls)
@@ -696,6 +709,19 @@ class ApplicationContext:
         """Get a bean instance by class and optional qualifier."""
         return self.bean_manager.get_bean(object_cls, qualifier)
 
+    def must_get_bean(
+        self, object_cls: Type[BT], qualifier: Optional[str] = None
+    ) -> BT:
+        """Get a bean instance, raising if not found."""
+        result = self.get_bean(object_cls, qualifier)
+        if result is None:
+            name = object_cls.__name__
+            msg = f"Bean {name} not found"
+            if qualifier:
+                msg += f" with qualifier '{qualifier}'"
+            raise LookupError(msg)
+        return result
+
     def register_bean_collection(self, bean_cls: Type[BeanCollection]) -> None:
         """Register a bean collection class in the application context."""
         self.bean_manager.register_bean_collection(bean_cls)
@@ -704,6 +730,14 @@ class ApplicationContext:
     def get_properties(self, properties_cls: Type[PT]) -> Optional[PT]:
         """Get a properties instance by class."""
         return self.properties_manager.get_properties(properties_cls)
+
+    def must_get_properties(self, properties_cls: Type[PT]) -> PT:
+        """Get a properties instance, raising if not found."""
+        result = self.get_properties(properties_cls)
+        if result is None:
+            name = properties_cls.__name__
+            raise LookupError(f"Properties {name} not found")
+        return result
 
     def register_properties(self, properties_cls: Type[Properties]) -> None:
         """Register a properties class in the application context."""

--- a/py_spring_core/core/application/context/application_context.py
+++ b/py_spring_core/core/application/context/application_context.py
@@ -4,7 +4,6 @@ from typing import (
     Annotated,
     Any,
     Callable,
-    Mapping,
     Optional,
     Type,
     TypeVar,
@@ -18,6 +17,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 import py_spring_core.core.utils as framework_utils
+from py_spring_core.core.application.application_registry import ApplicationRegistry
 from py_spring_core.core.application.commons import AppEntities
 from py_spring_core.core.application.context.application_context_config import (
     ApplicationContextConfig,
@@ -106,11 +106,11 @@ class DependencyInjector:
 
     def _inject_properties_dependency(
         self,
-        entity: Type[AppEntities],
+        target: object,
         attr_name: str,
         properties_cls: Type[Properties],
     ) -> bool:
-        """Inject a properties dependency into an entity."""
+        """Inject a properties dependency into a target instance."""
         if self._app_context is None:
             return False
 
@@ -121,7 +121,7 @@ class DependencyInjector:
                 f"is not found in properties file for class: {properties_cls.get_name()} "
                 f"with key: {properties_cls.get_key()}"
             )
-        setattr(entity, attr_name, optional_properties)
+        setattr(target, attr_name, optional_properties)
         return True
 
     def _collect_instances_by_type(self, element_cls: type) -> list[object]:
@@ -137,7 +137,7 @@ class DependencyInjector:
 
     def _try_inject_collection_dependency(
         self,
-        entity: Type[AppEntities],
+        target: object,
         attr_name: str,
         entity_cls: type,
     ) -> bool:
@@ -161,7 +161,7 @@ class DependencyInjector:
             collected_instances = self._collect_instances_by_type(element_cls)
             value = {type(inst).__name__: inst for inst in collected_instances}
 
-        setattr(entity, attr_name, value)
+        setattr(target, attr_name, value)
         logger.success(
             f"[COLLECTION INJECTION SUCCESS] Injected {len(collected_instances)} instances "
             f"of {element_cls.__name__} as {origin.__name__} into {attr_name}"
@@ -170,7 +170,7 @@ class DependencyInjector:
 
     def _try_inject_entity_dependency(
         self,
-        entity: Type[AppEntities],
+        target: object,
         attr_name: str,
         entity_cls: type,
         qualifier: Optional[str],
@@ -187,7 +187,7 @@ class DependencyInjector:
         for getter in entity_getters:
             optional_entity = getter(entity_cls, qualifier)
             if optional_entity is not None:
-                setattr(entity, attr_name, optional_entity)
+                setattr(target, attr_name, optional_entity)
                 logger.success(
                     f"[DEPENDENCY INJECTION SUCCESS] Inject dependency for {entity_cls.__name__} "
                     f"in attribute: {attr_name}"
@@ -195,9 +195,10 @@ class DependencyInjector:
                 return True
         return False
 
-    def inject_dependencies(self, entity: Type[AppEntities]) -> None:
-        """Inject dependencies for a given entity based on its annotations."""
-        for attr_name, annotated_type in entity.__annotations__.items():
+    def inject_dependencies(self, target: object) -> None:
+        """Inject dependencies into a target instance based on its class annotations."""
+        target_cls = type(target) if not isinstance(target, type) else target
+        for attr_name, annotated_type in target_cls.__annotations__.items():
             entity_cls, qualifier = self._extract_qualifier_from_annotation(
                 annotated_type
             )
@@ -211,17 +212,17 @@ class DependencyInjector:
                 continue
 
             if not isclass(entity_cls):
-                self._try_inject_collection_dependency(entity, attr_name, entity_cls)
+                self._try_inject_collection_dependency(target, attr_name, entity_cls)
                 continue
 
             # Handle Properties injection
             if issubclass(entity_cls, Properties):
-                if self._inject_properties_dependency(entity, attr_name, entity_cls):
+                if self._inject_properties_dependency(target, attr_name, entity_cls):
                     continue
 
             # Try to inject entity dependency
             if self._try_inject_entity_dependency(
-                entity, attr_name, entity_cls, qualifier
+                target, attr_name, entity_cls, qualifier
             ):
                 continue
 
@@ -238,8 +239,13 @@ class DependencyInjector:
 class ComponentManager:
     """Manages component registration and instantiation."""
 
-    def __init__(self, container_manager: ContainerManager):
+    def __init__(
+        self,
+        container_manager: ContainerManager,
+        dependency_injector: Optional["DependencyInjector"] = None,
+    ):
         self.container_manager = container_manager
+        self.dependency_injector = dependency_injector
 
     def _determine_target_cls_name(
         self, component_cls: type, qualifier: Optional[str]
@@ -345,7 +351,10 @@ class ComponentManager:
                     ),
                 )
             case ComponentScope.Prototype:
-                return cast(T, target_cls())
+                instance = target_cls()
+                if self.dependency_injector is not None:
+                    self.dependency_injector.inject_dependencies(instance)
+                return cast(T, instance)
 
     def _init_singleton_component(
         self, component_cls: Type[Component], component_cls_name: str
@@ -494,13 +503,13 @@ class BeanManager:
         return bean
 
     def _inject_bean_collection_dependencies(
-        self, bean_collection_cls: Type[BeanCollection]
+        self, bean_collection_instance: BeanCollection
     ) -> None:
-        """Inject dependencies for a bean collection."""
+        """Inject dependencies for a bean collection instance."""
         logger.info(
-            f"[BEAN COLLECTION DEPENDENCY INJECTION] Injecting dependencies for {bean_collection_cls.get_name()}"
+            f"[BEAN COLLECTION DEPENDENCY INJECTION] Injecting dependencies for {bean_collection_instance.get_name()}"
         )
-        self.dependency_injector.inject_dependencies(bean_collection_cls)
+        self.dependency_injector.inject_dependencies(bean_collection_instance)
 
     def _validate_bean_view(self, view: BeanView, collection_name: str) -> None:
         """Validate a bean view before adding it to the container."""
@@ -526,7 +535,7 @@ class BeanManager:
             )
 
             collection = bean_collection_cls()
-            self._inject_bean_collection_dependencies(bean_collection_cls)
+            self._inject_bean_collection_dependencies(collection)
 
             bean_views = collection.scan_beans()
             for view in bean_views:
@@ -611,10 +620,6 @@ class PropertiesManager:
                 properties_key
             ] = optional_properties
 
-        # Update the global properties loader reference
-        _PropertiesLoader.optional_loaded_properties = (
-            self.container_manager.properties_instances
-        )
 
 
 class ApplicationContext:
@@ -631,16 +636,24 @@ class ApplicationContext:
     a single instance of the application context throughout the application's lifetime.
     """
 
-    def __init__(self, config: ApplicationContextConfig, server: FastAPI) -> None:
+    def __init__(
+        self,
+        config: ApplicationContextConfig,
+        server: FastAPI,
+        registry: Optional[ApplicationRegistry] = None,
+    ) -> None:
         self.server = server
         self.config = config
+        self.registry = registry or ApplicationRegistry()
         self.all_file_paths: set[str] = set()
         self.providers: list[EntityProvider] = []
 
         # Initialize managers
         self.container_manager = ContainerManager()
         self.dependency_injector = DependencyInjector(self.container_manager)
-        self.component_manager = ComponentManager(self.container_manager)
+        self.component_manager = ComponentManager(
+            self.container_manager, self.dependency_injector
+        )
         self.bean_manager = BeanManager(
             self.container_manager, self.dependency_injector
         )
@@ -748,20 +761,18 @@ class ApplicationContext:
         # Initialize singleton beans
         self.bean_manager.init_singleton_beans()
 
+    def inject_dependencies_for_instance(self, instance: object) -> None:
+        """Inject dependencies into a specific instance."""
+        self.dependency_injector.inject_dependencies(instance)
+
     def inject_dependencies_for_external_object(self, target_cls: Type[Any]) -> None:
-        """Inject dependencies for an external object."""
+        """Inject dependencies for an external object (class-level, for middlewares etc.)."""
         self.dependency_injector.inject_dependencies(target_cls)
 
     def inject_dependencies_for_app_entities(self) -> None:
-        """Inject dependencies for all registered app entities."""
-        containers: list[Mapping[str, Type[AppEntities]]] = [
-            self.container_manager.component_classes,
-            self.container_manager.controller_classes,
-        ]
-
-        for container in containers:
-            for cls_name, cls in container.items():
-                self.dependency_injector.inject_dependencies(cls)
+        """Inject dependencies for all registered singleton component instances."""
+        for instance in self.container_manager.component_instances.values():
+            self.dependency_injector.inject_dependencies(instance)
 
     def _validate_entity_provider_dependencies(self, provider: EntityProvider) -> None:
         """Validate dependencies for a single entity provider."""

--- a/py_spring_core/core/application/py_spring_application.py
+++ b/py_spring_core/core/application/py_spring_application.py
@@ -262,7 +262,7 @@ class PySpringApplication:
             routes = self.registry.routes.get(name, set())
             controller.post_construct()
             controller._register_decorated_routes(routes)
-            router = controller.get_router()
+            router = controller.must_get_router()
             self.fastapi.include_router(router)
             logger.debug(f"[CONTROLLER INIT] Controller {name} initialized")
 

--- a/py_spring_core/core/application/py_spring_application.py
+++ b/py_spring_core/core/application/py_spring_application.py
@@ -15,6 +15,7 @@ from py_spring_core.commons.type_checking_service import TypeCheckingService
 from py_spring_core.core.application.application_config import (
     ApplicationConfigRepository,
 )
+from py_spring_core.core.application.application_registry import ApplicationRegistry
 from py_spring_core.core.application.commons import AppEntities
 from py_spring_core.core.application.context.application_context import (
     ApplicationContext,
@@ -26,7 +27,6 @@ from py_spring_core.core.application.loguru_config import LogFormat
 from py_spring_core.core.entities.bean_collection.bean_collection import BeanCollection
 from py_spring_core.core.entities.component.component import Component, ComponentLifeCycle
 from py_spring_core.core.entities.controllers.rest_controller import RestController
-from py_spring_core.core.entities.controllers.route_mapping import RouteMapping
 from py_spring_core.core.entities.entity_provider.entity_provider import EntityProvider
 from py_spring_core.core.entities.middlewares.middleware import Middleware
 from py_spring_core.core.entities.middlewares.middleware_registry import (
@@ -94,8 +94,11 @@ class PySpringApplication:
             properties_path=self.app_config.properties_file_path
         )
         self.fastapi = FastAPI()
+        self.registry = ApplicationRegistry()
         self.app_context = ApplicationContext(
-            config=self.app_context_config, server=self.fastapi
+            config=self.app_context_config,
+            server=self.fastapi,
+            registry=self.registry,
         )
 
         self.classes_with_handlers: dict[
@@ -160,12 +163,6 @@ class PySpringApplication:
             f"[REST CONTROLLER INIT] Register router for controller: {_cls.__name__}"
         )
         self.app_context.register_controller(_cls)
-        _cls.app = self.fastapi
-        router_prefix = _cls.get_router_prefix()
-        logger.debug(
-            f"[REST CONTROLLER INIT] Register router with prefix: {router_prefix}"
-        )
-        _cls.router = APIRouter(prefix=router_prefix)
 
     def _handle_register_bean_collection(self, _cls: Type[BeanCollection]) -> None:
         logger.debug(
@@ -205,7 +202,32 @@ class PySpringApplication:
         ]
         return classes_to_inject
 
+    def _drain_pending_registrations(self) -> None:
+        """Move import-time decorator registrations into this app's registry."""
+        from py_spring_core.core.entities.controllers.route_mapping import (
+            drain_pending_routes,
+        )
+        from py_spring_core.event.application_event_handler_registry import (
+            drain_pending_event_handlers,
+        )
+        from py_spring_core.exception_handler.exception_handler_registry import (
+            drain_pending_exception_handlers,
+        )
+
+        for route in drain_pending_routes():
+            self.registry.routes.setdefault(route.class_name, set()).add(route)
+
+        for handler in drain_pending_event_handlers():
+            event_name = handler.event_type.__name__
+            self.registry.event_handlers.setdefault(event_name, [])
+            if handler not in self.registry.event_handlers[event_name]:
+                self.registry.event_handlers[event_name].append(handler)
+
+        for exc_name, handler_func in drain_pending_exception_handlers():
+            self.registry.exception_handlers[exc_name] = handler_func
+
     def _init_app(self) -> None:
+        self._drain_pending_registrations()
         classes_to_inject = self._prepare_injected_classes()
         self._inject_application_context_to_context_required(classes_to_inject)
         self._register_app_entities(classes_to_inject)
@@ -233,7 +255,11 @@ class PySpringApplication:
         controllers = self.app_context.get_controller_instances()
         for controller in controllers:
             name = controller.__class__.__name__
-            routes = RouteMapping.routes.get(name, set())
+            router_prefix = controller.get_router_prefix()
+            controller.app = self.fastapi
+            controller.router = APIRouter(prefix=router_prefix)
+            self.app_context.inject_dependencies_for_instance(controller)
+            routes = self.registry.routes.get(name, set())
             controller.post_construct()
             controller._register_decorated_routes(routes)
             router = controller.get_router()

--- a/py_spring_core/core/application/py_spring_application.py
+++ b/py_spring_core/core/application/py_spring_application.py
@@ -227,8 +227,8 @@ class PySpringApplication:
             self.registry.exception_handlers[exc_name] = handler_func
 
     def _init_app(self) -> None:
-        self._drain_pending_registrations()
         classes_to_inject = self._prepare_injected_classes()
+        self._drain_pending_registrations()
         self._inject_application_context_to_context_required(classes_to_inject)
         self._register_app_entities(classes_to_inject)
         self.app_context.load_properties()

--- a/py_spring_core/core/entities/controllers/rest_controller.py
+++ b/py_spring_core/core/entities/controllers/rest_controller.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Iterable
+from typing import Iterable, Optional
 
 from fastapi import APIRouter, FastAPI
 
@@ -20,8 +20,9 @@ class RestController:
     Subclasses of `RestController` should override the `register_routes` methods to add their own routes and middleware to the controller.
     """
 
-    app: FastAPI
-    router: APIRouter
+    def __init__(self) -> None:
+        self.app: Optional[FastAPI] = None
+        self.router: Optional[APIRouter] = None
 
     class Config:
         prefix: str = ""

--- a/py_spring_core/core/entities/controllers/rest_controller.py
+++ b/py_spring_core/core/entities/controllers/rest_controller.py
@@ -30,6 +30,8 @@ class RestController:
     def post_construct(self) -> None: ...
 
     def _register_decorated_routes(self, routes: Iterable[RouteRegistration]) -> None:
+        if self.router is None:
+            raise RuntimeError("Router not initialized; cannot register routes")
         for route in routes:
             bound_method = partial(route.func, self)
             self.router.add_api_route(
@@ -56,7 +58,15 @@ class RestController:
                 name=route.name,
             )
 
-    def get_router(self) -> APIRouter:
+    def get_router(self) -> Optional[APIRouter]:
+        return self.router
+
+    def must_get_router(self) -> APIRouter:
+        """Get the router, raising if not initialized."""
+        if self.router is None:
+            raise LookupError(
+                f"Router not initialized for controller {self.get_name()}"
+            )
         return self.router
 
     @classmethod

--- a/py_spring_core/core/entities/controllers/route_mapping.py
+++ b/py_spring_core/core/entities/controllers/route_mapping.py
@@ -100,32 +100,25 @@ class RouteRegistration(BaseModel):
         return hash((self.method, self.path))
 
 
-class RouteMapping:
-    """Registry for storing and managing route registrations by controller class.
-    
-    This class maintains a mapping of controller class names to their
-    associated route registrations, enabling efficient route lookup
-    and management within the PySpring framework.
-    
-    Attributes:
-        routes (dict[str, set[RouteRegistration]]): Mapping of class names to route sets
-    """
-    routes: dict[str, set[RouteRegistration]] = {}
+# Module-level staging area for import-time route registrations.
+# Drained into ApplicationRegistry at app boot, then cleared.
+_pending_routes: list[RouteRegistration] = []
 
-    @classmethod
-    def register_route(cls, route_registration: RouteRegistration) -> None:
-        """Register a route for a specific controller class.
-        
-        Adds the given route registration to the routes mapping,
-        creating a new set for the class if it doesn't exist.
-        
-        Args:
-            route_registration (RouteRegistration): The route to register
-        """
-        optional_routes = cls.routes.get(route_registration.class_name, None)
-        if optional_routes is None:
-            cls.routes[route_registration.class_name] = set()
-        cls.routes[route_registration.class_name].add(route_registration)
+
+def drain_pending_routes() -> list[RouteRegistration]:
+    """Return all pending route registrations and clear the staging area."""
+    routes = list(_pending_routes)
+    _pending_routes.clear()
+    return routes
+
+
+class RouteMapping:
+    """Namespace for route registration utilities.
+
+    Route registrations collected at import time via decorators are stored
+    in a module-level pending list and drained into the ApplicationRegistry
+    when the application boots.
+    """
 
 
 def _create_route_decorator(method: HTTPMethod):
@@ -223,7 +216,7 @@ def _create_route_decorator(method: HTTPMethod):
                 include_in_schema=include_in_schema,
                 name=name,
             )
-            RouteMapping.register_route(route_registration)
+            _pending_routes.append(route_registration)
 
             @wraps(func)
             def wrapper(*args: Any, **kwargs: Any):

--- a/py_spring_core/core/entities/properties/properties_loader.py
+++ b/py_spring_core/core/entities/properties/properties_loader.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Type
 
 import cachetools
 import yaml
@@ -16,10 +16,7 @@ class _PropertiesLoader:
     The `_PropertiesLoader` class is responsible for loading properties from a file, validating them against a set of known `Properties` classes, and providing access to the loaded properties.
     The class supports loading properties from JSON or YAML files, and raises appropriate errors if the file extension is unsupported or the properties keys are invalid.
     The `load_properties` method returns a dictionary of `Properties` instances, where the keys match the keys in the properties file.
-    The `get_properties` method provides a way to retrieve a specific `Properties` instance by its key, if it has been previously loaded.
     """
-
-    optional_loaded_properties: dict[str, Properties] = {}
 
     def __init__(
         self, properties_path: str, properties_classes: list[Type[Properties]]
@@ -84,8 +81,3 @@ class _PropertiesLoader:
             properties[key] = properties_cls.model_validate(value)
         return properties
 
-    @classmethod
-    def get_properties(cls, _key: str) -> Optional[Properties]:
-        if cls.optional_loaded_properties is None:
-            raise ValueError("[PROPERTIES NOT LOADED] Properties not loaded yet")
-        return cls.optional_loaded_properties.get(_key)

--- a/py_spring_core/event/application_event_handler_registry.py
+++ b/py_spring_core/event/application_event_handler_registry.py
@@ -1,5 +1,5 @@
 from threading import Thread
-from typing import Callable, ClassVar, Optional, Type
+from typing import Callable, Optional, Type
 
 from loguru import logger
 from pydantic import BaseModel
@@ -8,9 +8,40 @@ from py_spring_core.core.entities.component.component import Component
 from py_spring_core.core.interfaces.application_context_required import (
     ApplicationContextRequired,
 )
-from py_spring_core.event.commons import ApplicationEvent, EventQueue, _ShutdownSentinel
+from py_spring_core.event.commons import ApplicationEvent, _ShutdownSentinel
 
 EventHandlerT = Callable[[Component, ApplicationEvent], None]
+
+
+# Module-level staging area for import-time event handler registrations.
+# Drained into ApplicationRegistry at app boot, then cleared.
+_pending_event_handlers: list["EventHandler"] = []
+
+
+def _register_event_handler(
+    event_type: Type[ApplicationEvent], handler: EventHandlerT
+) -> None:
+    """Build an EventHandler from the decorated function and stage it."""
+    handler_name = getattr(handler, "__qualname__", "")
+    func_name_parts = handler_name.split(".")
+    if len(func_name_parts) != 2:
+        raise ValueError("Handler must be a member function of a class")
+    class_name, func_name = func_name_parts
+    event_handler = EventHandler(
+        class_name=class_name,
+        func_name=func_name,
+        event_type=event_type,
+        func=handler,
+    )
+    if event_handler not in _pending_event_handlers:
+        _pending_event_handlers.append(event_handler)
+
+
+def drain_pending_event_handlers() -> list["EventHandler"]:
+    """Return all pending event handler registrations and clear the staging area."""
+    handlers = list(_pending_event_handlers)
+    _pending_event_handlers.clear()
+    return handlers
 
 
 def EventListener(event_type: Type[ApplicationEvent]) -> Callable:
@@ -21,9 +52,9 @@ def EventListener(event_type: Type[ApplicationEvent]) -> Callable:
 
     def decorator(func: EventHandlerT) -> EventHandlerT:
         if not issubclass(event_type, ApplicationEvent):
-            raise ValueError(f"Event type must be a subclass of ApplicationEvent")
+            raise ValueError("Event type must be a subclass of ApplicationEvent")
 
-        ApplicationEventHandlerRegistry.register_event_handler(event_type, func)
+        _register_event_handler(event_type, func)
         return func
 
     return decorator
@@ -59,11 +90,8 @@ class ApplicationEventHandlerRegistry(Component, ApplicationContextRequired):
     - Binds event handlers to their corresponding components
     """
 
-    _class_event_handlers: ClassVar[dict[str, list[EventHandler]]] = {}
-
     def __init__(self) -> None:
         self._event_handlers: dict[str, list[EventHandler]] = {}
-        self._event_message_queue = EventQueue.queue
         self._message_thread: Optional[Thread] = None
 
     def post_construct(self) -> None:
@@ -80,28 +108,7 @@ class ApplicationEventHandlerRegistry(Component, ApplicationContextRequired):
             component.__class__.__name__: component
             for component in app_context.get_singleton_component_instances()
         }
-        self._event_handlers = self._class_event_handlers
-
-    @classmethod
-    def register_event_handler(
-        cls, event_type: Type[ApplicationEvent], handler: EventHandlerT
-    ):
-        event_name = event_type.__name__
-        handler_name = getattr(handler, "__qualname__", "")
-        func_name_parts = handler_name.split(".")
-        if len(func_name_parts) != 2:
-            raise ValueError(f"Handler must be a member function of a class")
-        class_name, func_name = func_name_parts
-        if event_name not in cls._class_event_handlers:
-            cls._class_event_handlers[event_name] = []
-        event_handler = EventHandler(
-            class_name=class_name,
-            func_name=func_name,
-            event_type=event_type,
-            func=handler,
-        )
-        if event_handler not in cls._class_event_handlers[event_name]:
-            cls._class_event_handlers[event_name].append(event_handler)
+        self._event_handlers = app_context.registry.event_handlers
 
     def get_event_handlers(
         self, event_type: Type[ApplicationEvent]
@@ -111,9 +118,11 @@ class ApplicationEventHandlerRegistry(Component, ApplicationContextRequired):
         return handlers
 
     def _handle_messages(self) -> None:
+        app_context = self.get_application_context()
+        event_queue = app_context.registry.event_queue
         logger.info("Event message handler thread started...")
         while True:
-            message = self._event_message_queue.get()
+            message = event_queue.get()
             if isinstance(message, _ShutdownSentinel):
                 logger.info("Event message handler thread stopping...")
                 break
@@ -134,7 +143,8 @@ class ApplicationEventHandlerRegistry(Component, ApplicationContextRequired):
     def shutdown(self, timeout: float = 5.0) -> None:
         """Stop the event message handler thread gracefully."""
         if self._message_thread is not None and self._message_thread.is_alive():
-            self._event_message_queue.put(_ShutdownSentinel())
+            app_context = self.get_application_context()
+            app_context.registry.event_queue.put(_ShutdownSentinel())
             self._message_thread.join(timeout=timeout)
             if self._message_thread.is_alive():
                 logger.warning("Event message handler thread did not stop within timeout")

--- a/py_spring_core/event/application_event_publisher.py
+++ b/py_spring_core/event/application_event_publisher.py
@@ -1,16 +1,11 @@
-from typing import TypeVar
-
 from py_spring_core.core.entities.component.component import Component
-from py_spring_core.event.application_event_handler_registry import (
-    ApplicationEvent,
-    ApplicationEventHandlerRegistry,
+from py_spring_core.core.interfaces.application_context_required import (
+    ApplicationContextRequired,
 )
-from py_spring_core.event.commons import EventQueue
-
-T = TypeVar("T", bound=ApplicationEvent)
+from py_spring_core.event.commons import ApplicationEvent
 
 
-class ApplicationEventPublisher(Component):
+class ApplicationEventPublisher(Component, ApplicationContextRequired):
     """
     The ApplicationEventPublisher is a component that publishes application events.
     It is responsible for publishing application events to the event message queue.
@@ -19,8 +14,6 @@ class ApplicationEventPublisher(Component):
     - Publishes application events to the event message queue
     """
 
-    def __init__(self):
-        self.event_message_queue = EventQueue.queue
-
     def publish(self, event: ApplicationEvent) -> None:
-        self.event_message_queue.put(event)
+        app_context = self.get_application_context()
+        app_context.registry.event_queue.put(event)

--- a/py_spring_core/event/commons.py
+++ b/py_spring_core/event/commons.py
@@ -1,5 +1,3 @@
-from queue import Queue
-
 from pydantic import BaseModel
 
 
@@ -7,7 +5,3 @@ class ApplicationEvent(BaseModel): ...
 
 
 class _ShutdownSentinel(ApplicationEvent): ...
-
-
-class EventQueue:
-    queue: Queue[ApplicationEvent] = Queue()

--- a/py_spring_core/exception_handler/decorator.py
+++ b/py_spring_core/exception_handler/decorator.py
@@ -1,18 +1,16 @@
-
-
 from functools import wraps
-from typing import Any, Callable, Type
-
+from typing import Any, Callable, Type, TypeVar
 
 from py_spring_core.exception_handler.exception_handler_registry import ExceptionHandlerRegistry
 
+E = TypeVar("E", bound=Exception)
 
-def ExceptionHandler(exception_cls: Type[Exception]) -> Callable[[Callable[[Exception], Any]], Callable]:
-    def decorator(func: Callable[[Exception], Any]) -> Callable:
+
+def ExceptionHandler(exception_cls: Type[E]) -> Callable[[Callable[[E], Any]], Callable]:
+    def decorator(func: Callable[[E], Any]) -> Callable:
         @wraps(func)
         def wrapper(*args, **kwargs) -> Any:
             return func(*args, **kwargs)
         ExceptionHandlerRegistry.register(exception_cls, wrapper)
         return wrapper
-    
     return decorator

--- a/py_spring_core/exception_handler/exception_handler_registry.py
+++ b/py_spring_core/exception_handler/exception_handler_registry.py
@@ -1,26 +1,32 @@
-
-
 from typing import Any, Callable, Type, TypeVar
 
 from loguru import logger
 
 E = TypeVar('E', bound=Exception)
 
+# Module-level staging area for import-time exception handler registrations.
+# Drained into ApplicationRegistry at app boot, then cleared.
+_pending_exception_handlers: list[tuple[str, Callable]] = []
+
+
+def drain_pending_exception_handlers() -> list[tuple[str, Callable]]:
+    """Return all pending exception handler registrations and clear the staging area."""
+    handlers = list(_pending_exception_handlers)
+    _pending_exception_handlers.clear()
+    return handlers
+
+
 class ExceptionHandlerRegistry:
-    _handlers: dict[str, Callable[[Any], Any]] = {}
 
     @classmethod
-    def register(cls, exception_cls: Type[E], handler: Callable[[E], Any]):
+    def register(cls, exception_cls: Type[E], handler: Callable[[E], Any]) -> None:
         key = exception_cls.__name__
         handler_name = getattr(handler, "__name__", repr(handler))
         logger.debug(f"Registering exception handler for {key}: {handler_name}")
-        if key in cls._handlers:
-            error_message = f"Exception handler for {exception_cls} already registered"
-            logger.error(error_message)
-            raise RuntimeError(error_message)
-        
-        cls._handlers[exception_cls.__name__] = handler
-
-    @classmethod
-    def get_handler(cls, exception_cls: Type[E]) -> Callable[[E], Any]:
-        return cls._handlers[exception_cls.__name__]
+        # Check for duplicates in pending list
+        for existing_key, _ in _pending_exception_handlers:
+            if existing_key == key:
+                error_message = f"Exception handler for {exception_cls} already registered"
+                logger.error(error_message)
+                raise RuntimeError(error_message)
+        _pending_exception_handlers.append((key, handler))

--- a/tests/test_application_context.py
+++ b/tests/test_application_context.py
@@ -164,13 +164,14 @@ class TestApplicationContext:
         retrieved_properties = app_context.get_properties(TestProperties)
         assert retrieved_properties is properties_instance
 
-    def test_inject_dependencies_for_components_and_controllers(
+    def test_inject_dependencies_for_components(
         self, app_context: ApplicationContext
     ):
         """
-        Tests the injection of dependencies for components and controllers in the ApplicationContext.
+        Tests the injection of dependencies for component instances in the ApplicationContext.
 
-        This test ensures that the ApplicationContext correctly injects the dependencies for the registered components and controllers. It verifies that the necessary dependencies are available and accessible on the component and controller instances.
+        This test ensures that the ApplicationContext correctly injects the dependencies
+        onto singleton component instances (not on classes).
         """
 
         class TestNestedComponent(Component): ...
@@ -178,17 +179,36 @@ class TestApplicationContext:
         class TestComponent(Component):
             test_nested_component: TestNestedComponent
 
+        app_context.register_component(TestComponent)
+        app_context.register_component(TestNestedComponent)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        test_component_instance = app_context.get_component(TestComponent)
+        assert test_component_instance is not None
+        assert hasattr(test_component_instance, "test_nested_component")
+        assert isinstance(
+            test_component_instance.test_nested_component, TestNestedComponent
+        )
+
+    def test_inject_dependencies_for_controllers(
+        self, app_context: ApplicationContext
+    ):
+        """
+        Tests that controller instances receive DI when injected via inject_dependencies_for_instance.
+        """
+
+        class TestComponent(Component): ...
+
         class TestController(RestController):
             test_component: TestComponent
 
         app_context.register_component(TestComponent)
-        app_context.register_component(TestNestedComponent)
         app_context.register_controller(TestController)
         app_context.init_ioc_container()
         app_context.inject_dependencies_for_app_entities()
-        assert hasattr(TestComponent, "test_nested_component") and isinstance(
-            TestComponent.test_nested_component, TestNestedComponent
-        )
-        assert hasattr(TestController, "test_component") and isinstance(
-            TestController.test_component, TestComponent
-        )
+
+        controller = app_context.get_controller_instances()[0]
+        app_context.inject_dependencies_for_instance(controller)
+        assert hasattr(controller, "test_component")
+        assert isinstance(controller.test_component, TestComponent)

--- a/tests/test_application_context.py
+++ b/tests/test_application_context.py
@@ -208,7 +208,7 @@ class TestApplicationContext:
         app_context.init_ioc_container()
         app_context.inject_dependencies_for_app_entities()
 
-        controller = app_context.get_controller_instances()[0]
+        controller: TestController = app_context.get_controller_instances()[0] # type: ignore
         app_context.inject_dependencies_for_instance(controller)
         assert hasattr(controller, "test_component")
         assert isinstance(controller.test_component, TestComponent)

--- a/tests/test_drain_e2e.py
+++ b/tests/test_drain_e2e.py
@@ -1,0 +1,483 @@
+"""
+End-to-end tests for _drain_pending_registrations.
+
+Verifies that decorator-registered routes, event handlers, and exception
+handlers are properly drained into the ApplicationRegistry and become
+functional after the full init sequence (scan → drain → register → init).
+
+Entity classes are defined at module level so that __qualname__ is clean
+(e.g. "ItemController.list_items" not "TestClass.test_method.<locals>...").
+"""
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from py_spring_core.core.application.application_registry import ApplicationRegistry
+from py_spring_core.core.application.context.application_context import (
+    ApplicationContext,
+    ApplicationContextConfig,
+)
+from py_spring_core.core.entities.component.component import Component, ComponentScope
+from py_spring_core.core.entities.controllers.rest_controller import RestController
+from py_spring_core.core.entities.controllers.route_mapping import (
+    DeleteMapping,
+    GetMapping,
+    PostMapping,
+    _pending_routes,
+    drain_pending_routes,
+)
+from py_spring_core.event.application_event_handler_registry import (
+    EventListener,
+    _pending_event_handlers,
+    drain_pending_event_handlers,
+)
+from py_spring_core.event.commons import ApplicationEvent
+from py_spring_core.exception_handler.decorator import ExceptionHandler
+from py_spring_core.exception_handler.exception_handler_registry import (
+    _pending_exception_handlers,
+    drain_pending_exception_handlers,
+)
+
+
+# ===========================================================================
+# Module-level entity definitions (clean __qualname__ for decorators)
+# ===========================================================================
+
+# --- Routes ---
+
+class ItemController(RestController):
+    class Config:
+        prefix = "/items"
+
+    @GetMapping("/")
+    def list_items(self):
+        return [{"id": 1, "name": "apple"}]
+
+
+class UserController(RestController):
+    class Config:
+        prefix = "/users"
+
+    @GetMapping("/")
+    def list_users(self):
+        return []
+
+    @PostMapping("/")
+    def create_user(self):
+        return {"created": True}
+
+    @DeleteMapping("/{user_id}")
+    def delete_user(self, user_id: int):
+        return {"deleted": user_id}
+
+
+class GhostController(RestController):
+    @GetMapping("/ghost")
+    def ghost(self):
+        return "boo"
+
+
+# --- Events ---
+
+class OrderPlaced(ApplicationEvent):
+    pass
+
+
+class UserCreated(ApplicationEvent):
+    pass
+
+
+class PaymentReceived(ApplicationEvent):
+    pass
+
+
+class SkippedEvent(ApplicationEvent):
+    pass
+
+
+class OrderService(Component):
+    class Config:
+        scope = ComponentScope.Singleton
+
+    def __init__(self):
+        self.handled_events = []
+
+    @EventListener(OrderPlaced)
+    def on_order_placed(self, event: OrderPlaced):
+        self.handled_events.append(event)
+
+
+class NotificationService(Component):
+    class Config:
+        scope = ComponentScope.Singleton
+        name = "NotificationService"
+
+    def __init__(self):
+        self.notified = False
+
+    @EventListener(UserCreated)
+    def on_user_created(self, event: UserCreated):
+        self.notified = True
+
+
+class BillingService(Component):
+    class Config:
+        name = "BillingService"
+
+    @EventListener(PaymentReceived)
+    def on_payment(self, event: PaymentReceived):
+        pass
+
+
+class AuditService(Component):
+    class Config:
+        name = "AuditService"
+
+    @EventListener(PaymentReceived)
+    def on_payment(self, event: PaymentReceived):
+        pass
+
+
+class SkippedComponent(Component):
+    @EventListener(SkippedEvent)
+    def handle(self, event: SkippedEvent):
+        pass
+
+
+# --- Exceptions ---
+
+class AppError(Exception):
+    pass
+
+
+class ServiceError(Exception):
+    pass
+
+
+class OrphanError(Exception):
+    pass
+
+
+@ExceptionHandler(AppError)
+def handle_app_error(exc: AppError):
+    return {"error": str(exc)}
+
+
+@ExceptionHandler(ServiceError)
+def handle_service_error(exc: ServiceError):
+    from fastapi.responses import JSONResponse
+    return JSONResponse(status_code=503, content={"detail": str(exc)})
+
+
+@ExceptionHandler(OrphanError)
+def handle_orphan(exc: OrphanError):
+    return "handled"
+
+
+# --- Full-sequence entities ---
+
+class TaskCompleted(ApplicationEvent):
+    pass
+
+
+class TaskError(Exception):
+    pass
+
+
+class TaskController(RestController):
+    class Config:
+        prefix = "/tasks"
+
+    @GetMapping("/")
+    def list_tasks(self):
+        return [{"task": "write tests"}]
+
+    @PostMapping("/")
+    def create_task(self):
+        return {"created": True}
+
+
+class TaskWorker(Component):
+    class Config:
+        scope = ComponentScope.Singleton
+        name = "TaskWorker"
+
+    def __init__(self):
+        self.completed = []
+
+    @EventListener(TaskCompleted)
+    def on_complete(self, event: TaskCompleted):
+        self.completed.append(event)
+
+
+@ExceptionHandler(TaskError)
+def handle_task_error(exc: TaskError):
+    from fastapi.responses import JSONResponse
+    return JSONResponse(status_code=500, content={"error": str(exc)})
+
+
+# Snapshot all decorator registrations from module-level definitions, then clear.
+_ROUTE_SNAPSHOT = list(_pending_routes)
+_EVENT_HANDLER_SNAPSHOT = list(_pending_event_handlers)
+_EXCEPTION_HANDLER_SNAPSHOT = list(_pending_exception_handlers)
+
+_pending_routes.clear()
+_pending_event_handlers.clear()
+_pending_exception_handlers.clear()
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _restore_pending_routes_for(*controller_names: str):
+    for r in _ROUTE_SNAPSHOT:
+        if r.class_name in controller_names:
+            _pending_routes.append(r)
+
+
+def _restore_pending_event_handlers_for(*class_names: str):
+    for h in _EVENT_HANDLER_SNAPSHOT:
+        if h.class_name in class_names:
+            _pending_event_handlers.append(h)
+
+
+def _restore_pending_exception_handlers_for(*exc_names: str):
+    for name, func in _EXCEPTION_HANDLER_SNAPSHOT:
+        if name in exc_names:
+            _pending_exception_handlers.append((name, func))
+
+
+def _drain_into_registry(registry: ApplicationRegistry) -> None:
+    """Replicate PySpringApplication._drain_pending_registrations."""
+    for route in drain_pending_routes():
+        registry.routes.setdefault(route.class_name, set()).add(route)
+
+    for handler in drain_pending_event_handlers():
+        event_name = handler.event_type.__name__
+        registry.event_handlers.setdefault(event_name, [])
+        if handler not in registry.event_handlers[event_name]:
+            registry.event_handlers[event_name].append(handler)
+
+    for exc_name, handler_func in drain_pending_exception_handlers():
+        registry.exception_handlers[exc_name] = handler_func
+
+
+def _wire_controllers(server, registry, app_context):
+    """Init controllers the same way PySpringApplication._init_controllers does."""
+    for ctrl in app_context.get_controller_instances():
+        name = ctrl.__class__.__name__
+        ctrl.app = server
+        ctrl.router = APIRouter(prefix=ctrl.get_router_prefix())
+        ctrl.post_construct()
+        ctrl._register_decorated_routes(registry.routes.get(name, set()))
+        server.include_router(ctrl.must_get_router())
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture(autouse=True)
+def _clear_all_pending():
+    _pending_routes.clear()
+    _pending_event_handlers.clear()
+    _pending_exception_handlers.clear()
+    yield
+    _pending_routes.clear()
+    _pending_event_handlers.clear()
+    _pending_exception_handlers.clear()
+
+
+@pytest.fixture
+def registry() -> ApplicationRegistry:
+    return ApplicationRegistry()
+
+
+@pytest.fixture
+def server() -> FastAPI:
+    return FastAPI()
+
+
+@pytest.fixture
+def app_context(server, registry):
+    config = ApplicationContextConfig(properties_path="")
+    return ApplicationContext(config, server=server, registry=registry)
+
+
+# ===========================================================================
+# E2E: Routes are drained and served via FastAPI
+# ===========================================================================
+
+
+class TestRoutesDrainE2E:
+
+    def test_get_route_is_callable_after_drain(self, server, registry, app_context):
+        _restore_pending_routes_for("ItemController")
+        _drain_into_registry(registry)
+
+        app_context.register_controller(ItemController)
+        _wire_controllers(server, registry, app_context)
+
+        client = TestClient(server)
+        resp = client.get("/items/")
+        assert resp.status_code == 200
+        assert resp.json() == [{"id": 1, "name": "apple"}]
+
+    def test_multiple_routes_on_same_controller(self, server, registry, app_context):
+        _restore_pending_routes_for("UserController")
+        _drain_into_registry(registry)
+
+        assert "UserController" in registry.routes
+        assert len(registry.routes["UserController"]) == 3
+
+        app_context.register_controller(UserController)
+        _wire_controllers(server, registry, app_context)
+
+        client = TestClient(server)
+        assert client.get("/users/").status_code == 200
+        assert client.post("/users/").status_code == 200
+        assert client.delete("/users/42").status_code == 200
+        assert client.delete("/users/42").json() == {"deleted": 42}
+
+    def test_no_routes_without_drain(self, registry):
+        """If drain is skipped, the registry stays empty."""
+        _restore_pending_routes_for("GhostController")
+        # Intentionally skip drain
+        assert registry.routes.get("GhostController") is None
+
+
+# ===========================================================================
+# E2E: Event handlers are drained and bound to components
+# ===========================================================================
+
+
+class TestEventHandlersDrainE2E:
+
+    def test_event_handler_registered_after_drain(self, registry):
+        _restore_pending_event_handlers_for("OrderService")
+        _drain_into_registry(registry)
+
+        assert "OrderPlaced" in registry.event_handlers
+        handlers = registry.event_handlers["OrderPlaced"]
+        assert len(handlers) == 1
+        assert handlers[0].class_name == "OrderService"
+        assert handlers[0].func_name == "on_order_placed"
+
+    def test_event_handler_callable_on_component_instance(self, registry, app_context):
+        _restore_pending_event_handlers_for("NotificationService")
+        _drain_into_registry(registry)
+
+        app_context.register_component(NotificationService)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        instance = app_context.get_component(NotificationService)
+        assert instance is not None
+
+        handler = registry.event_handlers["UserCreated"][0]
+        event = UserCreated()
+        handler.func(instance, event)
+        assert instance.notified is True
+
+    def test_multiple_handlers_for_same_event(self, registry):
+        _restore_pending_event_handlers_for("BillingService", "AuditService")
+        _drain_into_registry(registry)
+
+        assert len(registry.event_handlers["PaymentReceived"]) == 2
+        class_names = {h.class_name for h in registry.event_handlers["PaymentReceived"]}
+        assert class_names == {"BillingService", "AuditService"}
+
+    def test_no_handlers_without_drain(self, registry):
+        _restore_pending_event_handlers_for("SkippedComponent")
+        # Intentionally skip drain
+        assert registry.event_handlers.get("SkippedEvent") is None
+
+
+# ===========================================================================
+# E2E: Exception handlers are drained and callable
+# ===========================================================================
+
+
+class TestExceptionHandlersDrainE2E:
+
+    def test_exception_handler_registered_after_drain(self, registry):
+        _restore_pending_exception_handlers_for("AppError")
+        _drain_into_registry(registry)
+
+        assert "AppError" in registry.exception_handlers
+        result = registry.exception_handlers["AppError"](AppError("boom"))
+        assert result == {"error": "boom"}
+
+    def test_exception_handler_wired_into_fastapi(self, server, registry):
+        _restore_pending_exception_handlers_for("ServiceError")
+        _drain_into_registry(registry)
+
+        for exc_name, handler_func in registry.exception_handlers.items():
+            server.add_exception_handler(ServiceError, lambda req, exc: handler_func(exc))
+
+        @server.get("/fail")
+        def fail_route():
+            raise ServiceError("service down")
+
+        client = TestClient(server, raise_server_exceptions=False)
+        resp = client.get("/fail")
+        assert resp.status_code == 503
+        assert resp.json() == {"detail": "service down"}
+
+    def test_no_handlers_without_drain(self, registry):
+        _restore_pending_exception_handlers_for("OrphanError")
+        # Skip drain
+        assert registry.exception_handlers.get("OrphanError") is None
+
+
+# ===========================================================================
+# E2E: All three drain targets in a single init sequence
+# ===========================================================================
+
+
+class TestFullDrainSequence:
+
+    def test_all_drain_targets_populated_in_single_pass(self, server, registry, app_context):
+        """Simulate the real boot: decorators fire → drain → everything lands in registry."""
+        _restore_pending_routes_for("TaskController")
+        _restore_pending_event_handlers_for("TaskWorker")
+        _restore_pending_exception_handlers_for("TaskError")
+
+        _drain_into_registry(registry)
+
+        # --- verify all three are populated ---
+        assert "TaskController" in registry.routes
+        assert len(registry.routes["TaskController"]) == 2
+
+        assert "TaskCompleted" in registry.event_handlers
+        assert len(registry.event_handlers["TaskCompleted"]) == 1
+
+        assert "TaskError" in registry.exception_handlers
+
+        # --- wire up controller and verify routes are live ---
+        app_context.register_controller(TaskController)
+        app_context.register_component(TaskWorker)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        _wire_controllers(server, registry, app_context)
+
+        client = TestClient(server)
+        assert client.get("/tasks/").status_code == 200
+        assert client.get("/tasks/").json() == [{"task": "write tests"}]
+        assert client.post("/tasks/").json() == {"created": True}
+
+        # --- verify event handler is callable on the real component ---
+        worker = app_context.get_component(TaskWorker)
+        handler = registry.event_handlers["TaskCompleted"][0]
+        event = TaskCompleted()
+        handler.func(worker, event)
+        assert len(worker.completed) == 1
+
+        # --- verify exception handler is callable ---
+        result = registry.exception_handlers["TaskError"](TaskError("fail"))
+        assert result.status_code == 500

--- a/tests/test_drain_e2e.py
+++ b/tests/test_drain_e2e.py
@@ -9,6 +9,9 @@ Entity classes are defined at module level so that __qualname__ is clean
 (e.g. "ItemController.list_items" not "TestClass.test_method.<locals>...").
 """
 
+from collections.abc import Generator
+from typing import Any, Callable
+
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
@@ -24,10 +27,12 @@ from py_spring_core.core.entities.controllers.route_mapping import (
     DeleteMapping,
     GetMapping,
     PostMapping,
+    RouteRegistration,
     _pending_routes,
     drain_pending_routes,
 )
 from py_spring_core.event.application_event_handler_registry import (
+    EventHandler,
     EventListener,
     _pending_event_handlers,
     drain_pending_event_handlers,
@@ -51,7 +56,7 @@ class ItemController(RestController):
         prefix = "/items"
 
     @GetMapping("/")
-    def list_items(self):
+    def list_items(self) -> list[dict[str, Any]]:
         return [{"id": 1, "name": "apple"}]
 
 
@@ -60,21 +65,21 @@ class UserController(RestController):
         prefix = "/users"
 
     @GetMapping("/")
-    def list_users(self):
+    def list_users(self) -> list[Any]:
         return []
 
     @PostMapping("/")
-    def create_user(self):
+    def create_user(self) -> dict[str, bool]:
         return {"created": True}
 
     @DeleteMapping("/{user_id}")
-    def delete_user(self, user_id: int):
+    def delete_user(self, user_id: int) -> dict[str, int]:
         return {"deleted": user_id}
 
 
 class GhostController(RestController):
     @GetMapping("/ghost")
-    def ghost(self):
+    def ghost(self) -> str:
         return "boo"
 
 
@@ -100,11 +105,11 @@ class OrderService(Component):
     class Config:
         scope = ComponentScope.Singleton
 
-    def __init__(self):
-        self.handled_events = []
+    def __init__(self) -> None:
+        self.handled_events: list[OrderPlaced] = []
 
     @EventListener(OrderPlaced)
-    def on_order_placed(self, event: OrderPlaced):
+    def on_order_placed(self, event: OrderPlaced) -> None:
         self.handled_events.append(event)
 
 
@@ -113,11 +118,11 @@ class NotificationService(Component):
         scope = ComponentScope.Singleton
         name = "NotificationService"
 
-    def __init__(self):
-        self.notified = False
+    def __init__(self) -> None:
+        self.notified: bool = False
 
     @EventListener(UserCreated)
-    def on_user_created(self, event: UserCreated):
+    def on_user_created(self, event: UserCreated) -> None:
         self.notified = True
 
 
@@ -126,7 +131,7 @@ class BillingService(Component):
         name = "BillingService"
 
     @EventListener(PaymentReceived)
-    def on_payment(self, event: PaymentReceived):
+    def on_payment(self, event: PaymentReceived) -> None:
         pass
 
 
@@ -135,13 +140,13 @@ class AuditService(Component):
         name = "AuditService"
 
     @EventListener(PaymentReceived)
-    def on_payment(self, event: PaymentReceived):
+    def on_payment(self, event: PaymentReceived) -> None:
         pass
 
 
 class SkippedComponent(Component):
     @EventListener(SkippedEvent)
-    def handle(self, event: SkippedEvent):
+    def handle(self, event: SkippedEvent) -> None:
         pass
 
 
@@ -160,18 +165,18 @@ class OrphanError(Exception):
 
 
 @ExceptionHandler(AppError)
-def handle_app_error(exc: AppError):
+def handle_app_error(exc: AppError) -> dict[str, str]:
     return {"error": str(exc)}
 
 
 @ExceptionHandler(ServiceError)
-def handle_service_error(exc: ServiceError):
+def handle_service_error(exc: ServiceError) -> Any:
     from fastapi.responses import JSONResponse
     return JSONResponse(status_code=503, content={"detail": str(exc)})
 
 
 @ExceptionHandler(OrphanError)
-def handle_orphan(exc: OrphanError):
+def handle_orphan(exc: OrphanError) -> str:
     return "handled"
 
 
@@ -190,11 +195,11 @@ class TaskController(RestController):
         prefix = "/tasks"
 
     @GetMapping("/")
-    def list_tasks(self):
+    def list_tasks(self) -> list[dict[str, str]]:
         return [{"task": "write tests"}]
 
     @PostMapping("/")
-    def create_task(self):
+    def create_task(self) -> dict[str, bool]:
         return {"created": True}
 
 
@@ -203,24 +208,24 @@ class TaskWorker(Component):
         scope = ComponentScope.Singleton
         name = "TaskWorker"
 
-    def __init__(self):
-        self.completed = []
+    def __init__(self) -> None:
+        self.completed: list[TaskCompleted] = []
 
     @EventListener(TaskCompleted)
-    def on_complete(self, event: TaskCompleted):
+    def on_complete(self, event: TaskCompleted) -> None:
         self.completed.append(event)
 
 
 @ExceptionHandler(TaskError)
-def handle_task_error(exc: TaskError):
+def handle_task_error(exc: TaskError) -> Any:
     from fastapi.responses import JSONResponse
     return JSONResponse(status_code=500, content={"error": str(exc)})
 
 
 # Snapshot all decorator registrations from module-level definitions, then clear.
-_ROUTE_SNAPSHOT = list(_pending_routes)
-_EVENT_HANDLER_SNAPSHOT = list(_pending_event_handlers)
-_EXCEPTION_HANDLER_SNAPSHOT = list(_pending_exception_handlers)
+_ROUTE_SNAPSHOT: list[RouteRegistration] = list(_pending_routes)
+_EVENT_HANDLER_SNAPSHOT: list[EventHandler] = list(_pending_event_handlers)
+_EXCEPTION_HANDLER_SNAPSHOT: list[tuple[str, Callable[..., Any]]] = list(_pending_exception_handlers)
 
 _pending_routes.clear()
 _pending_event_handlers.clear()
@@ -232,19 +237,19 @@ _pending_exception_handlers.clear()
 # ===========================================================================
 
 
-def _restore_pending_routes_for(*controller_names: str):
+def _restore_pending_routes_for(*controller_names: str) -> None:
     for r in _ROUTE_SNAPSHOT:
         if r.class_name in controller_names:
             _pending_routes.append(r)
 
 
-def _restore_pending_event_handlers_for(*class_names: str):
+def _restore_pending_event_handlers_for(*class_names: str) -> None:
     for h in _EVENT_HANDLER_SNAPSHOT:
         if h.class_name in class_names:
             _pending_event_handlers.append(h)
 
 
-def _restore_pending_exception_handlers_for(*exc_names: str):
+def _restore_pending_exception_handlers_for(*exc_names: str) -> None:
     for name, func in _EXCEPTION_HANDLER_SNAPSHOT:
         if name in exc_names:
             _pending_exception_handlers.append((name, func))
@@ -265,7 +270,9 @@ def _drain_into_registry(registry: ApplicationRegistry) -> None:
         registry.exception_handlers[exc_name] = handler_func
 
 
-def _wire_controllers(server, registry, app_context):
+def _wire_controllers(
+    server: FastAPI, registry: ApplicationRegistry, app_context: ApplicationContext
+) -> None:
     """Init controllers the same way PySpringApplication._init_controllers does."""
     for ctrl in app_context.get_controller_instances():
         name = ctrl.__class__.__name__
@@ -282,7 +289,7 @@ def _wire_controllers(server, registry, app_context):
 
 
 @pytest.fixture(autouse=True)
-def _clear_all_pending():
+def _clear_all_pending() -> Generator[None]:
     _pending_routes.clear()
     _pending_event_handlers.clear()
     _pending_exception_handlers.clear()
@@ -303,7 +310,7 @@ def server() -> FastAPI:
 
 
 @pytest.fixture
-def app_context(server, registry):
+def app_context(server: FastAPI, registry: ApplicationRegistry) -> ApplicationContext:
     config = ApplicationContextConfig(properties_path="")
     return ApplicationContext(config, server=server, registry=registry)
 
@@ -315,7 +322,7 @@ def app_context(server, registry):
 
 class TestRoutesDrainE2E:
 
-    def test_get_route_is_callable_after_drain(self, server, registry, app_context):
+    def test_get_route_is_callable_after_drain(self, server: FastAPI, registry: ApplicationRegistry, app_context: ApplicationContext) -> None:
         _restore_pending_routes_for("ItemController")
         _drain_into_registry(registry)
 
@@ -327,7 +334,7 @@ class TestRoutesDrainE2E:
         assert resp.status_code == 200
         assert resp.json() == [{"id": 1, "name": "apple"}]
 
-    def test_multiple_routes_on_same_controller(self, server, registry, app_context):
+    def test_multiple_routes_on_same_controller(self, server: FastAPI, registry: ApplicationRegistry, app_context: ApplicationContext) -> None:
         _restore_pending_routes_for("UserController")
         _drain_into_registry(registry)
 
@@ -343,7 +350,7 @@ class TestRoutesDrainE2E:
         assert client.delete("/users/42").status_code == 200
         assert client.delete("/users/42").json() == {"deleted": 42}
 
-    def test_no_routes_without_drain(self, registry):
+    def test_no_routes_without_drain(self, registry: ApplicationRegistry) -> None:
         """If drain is skipped, the registry stays empty."""
         _restore_pending_routes_for("GhostController")
         # Intentionally skip drain
@@ -357,7 +364,7 @@ class TestRoutesDrainE2E:
 
 class TestEventHandlersDrainE2E:
 
-    def test_event_handler_registered_after_drain(self, registry):
+    def test_event_handler_registered_after_drain(self, registry: ApplicationRegistry) -> None:
         _restore_pending_event_handlers_for("OrderService")
         _drain_into_registry(registry)
 
@@ -367,7 +374,7 @@ class TestEventHandlersDrainE2E:
         assert handlers[0].class_name == "OrderService"
         assert handlers[0].func_name == "on_order_placed"
 
-    def test_event_handler_callable_on_component_instance(self, registry, app_context):
+    def test_event_handler_callable_on_component_instance(self, registry: ApplicationRegistry, app_context: ApplicationContext) -> None:
         _restore_pending_event_handlers_for("NotificationService")
         _drain_into_registry(registry)
 
@@ -383,7 +390,7 @@ class TestEventHandlersDrainE2E:
         handler.func(instance, event)
         assert instance.notified is True
 
-    def test_multiple_handlers_for_same_event(self, registry):
+    def test_multiple_handlers_for_same_event(self, registry: ApplicationRegistry) -> None:
         _restore_pending_event_handlers_for("BillingService", "AuditService")
         _drain_into_registry(registry)
 
@@ -391,7 +398,7 @@ class TestEventHandlersDrainE2E:
         class_names = {h.class_name for h in registry.event_handlers["PaymentReceived"]}
         assert class_names == {"BillingService", "AuditService"}
 
-    def test_no_handlers_without_drain(self, registry):
+    def test_no_handlers_without_drain(self, registry: ApplicationRegistry) -> None:
         _restore_pending_event_handlers_for("SkippedComponent")
         # Intentionally skip drain
         assert registry.event_handlers.get("SkippedEvent") is None
@@ -404,7 +411,7 @@ class TestEventHandlersDrainE2E:
 
 class TestExceptionHandlersDrainE2E:
 
-    def test_exception_handler_registered_after_drain(self, registry):
+    def test_exception_handler_registered_after_drain(self, registry: ApplicationRegistry) -> None:
         _restore_pending_exception_handlers_for("AppError")
         _drain_into_registry(registry)
 
@@ -412,7 +419,7 @@ class TestExceptionHandlersDrainE2E:
         result = registry.exception_handlers["AppError"](AppError("boom"))
         assert result == {"error": "boom"}
 
-    def test_exception_handler_wired_into_fastapi(self, server, registry):
+    def test_exception_handler_wired_into_fastapi(self, server: FastAPI, registry: ApplicationRegistry) -> None:
         _restore_pending_exception_handlers_for("ServiceError")
         _drain_into_registry(registry)
 
@@ -428,7 +435,7 @@ class TestExceptionHandlersDrainE2E:
         assert resp.status_code == 503
         assert resp.json() == {"detail": "service down"}
 
-    def test_no_handlers_without_drain(self, registry):
+    def test_no_handlers_without_drain(self, registry: ApplicationRegistry) -> None:
         _restore_pending_exception_handlers_for("OrphanError")
         # Skip drain
         assert registry.exception_handlers.get("OrphanError") is None
@@ -441,7 +448,7 @@ class TestExceptionHandlersDrainE2E:
 
 class TestFullDrainSequence:
 
-    def test_all_drain_targets_populated_in_single_pass(self, server, registry, app_context):
+    def test_all_drain_targets_populated_in_single_pass(self, server: FastAPI, registry: ApplicationRegistry, app_context: ApplicationContext) -> None:
         """Simulate the real boot: decorators fire → drain → everything lands in registry."""
         _restore_pending_routes_for("TaskController")
         _restore_pending_event_handlers_for("TaskWorker")
@@ -473,6 +480,7 @@ class TestFullDrainSequence:
 
         # --- verify event handler is callable on the real component ---
         worker = app_context.get_component(TaskWorker)
+        assert worker is not None
         handler = registry.event_handlers["TaskCompleted"][0]
         event = TaskCompleted()
         handler.func(worker, event)

--- a/tests/test_global_state_refactor.py
+++ b/tests/test_global_state_refactor.py
@@ -24,6 +24,7 @@ from py_spring_core.core.entities.component.component import Component, Componen
 from py_spring_core.core.entities.controllers.rest_controller import RestController
 from py_spring_core.core.entities.controllers.route_mapping import (
     GetMapping,
+    HTTPMethod,
     PostMapping,
     RouteRegistration,
     _pending_routes,
@@ -246,7 +247,7 @@ class TestApplicationRegistry:
         reg.routes["TestCtrl"] = {
             RouteRegistration(
                 class_name="TestCtrl",
-                method="GET",
+                method=HTTPMethod.GET,
                 path="/test",
                 func=lambda: None,
             )
@@ -254,7 +255,7 @@ class TestApplicationRegistry:
         reg.event_handlers["MyEvent"] = [{"some": "handler"}]
         reg.exception_handlers["ValueError"] = lambda e: None
         reg.loaded_properties["db"] = {"host": "localhost"}
-        reg.event_queue.put("msg")
+        reg.event_queue.put(ApplicationEvent())
 
         reg.clear()
 
@@ -381,6 +382,8 @@ class TestInstanceLevelDI:
 
         a = app_context.get_component(ConsumerA)
         b = app_context.get_component(ConsumerB)
+        assert a is not None
+        assert b is not None
 
         assert a is not b
         assert a.dep is b.dep  # same singleton
@@ -443,7 +446,7 @@ class TestEventQueueThroughRegistry:
         reg_a = ApplicationRegistry()
         reg_b = ApplicationRegistry()
 
-        reg_a.event_queue.put("event_for_a")
+        reg_a.event_queue.put(ApplicationEvent())
 
         assert not reg_b.event_queue.qsize()
         assert reg_a.event_queue.qsize() == 1

--- a/tests/test_global_state_refactor.py
+++ b/tests/test_global_state_refactor.py
@@ -1,0 +1,449 @@
+"""
+Tests for instance-owned application state (ApplicationRegistry, drain functions, instance-level DI).
+
+Covers:
+- Drain functions (routes, event handlers, exception handlers)
+- ApplicationRegistry isolation and clear()
+- Instance-level DI (not class-level)
+- Prototype DI per-instantiation
+- Controller instance-level app/router
+"""
+
+from abc import ABC, abstractmethod
+from typing import Annotated
+
+import pytest
+from fastapi import APIRouter, FastAPI
+
+from py_spring_core.core.application.application_registry import ApplicationRegistry
+from py_spring_core.core.application.context.application_context import (
+    ApplicationContext,
+    ApplicationContextConfig,
+)
+from py_spring_core.core.entities.component.component import Component, ComponentScope
+from py_spring_core.core.entities.controllers.rest_controller import RestController
+from py_spring_core.core.entities.controllers.route_mapping import (
+    GetMapping,
+    PostMapping,
+    RouteRegistration,
+    _pending_routes,
+    drain_pending_routes,
+)
+from py_spring_core.event.application_event_handler_registry import (
+    EventHandler,
+    EventListener,
+    _pending_event_handlers,
+    drain_pending_event_handlers,
+)
+from py_spring_core.event.commons import ApplicationEvent
+from py_spring_core.exception_handler.exception_handler_registry import (
+    ExceptionHandlerRegistry,
+    _pending_exception_handlers,
+    drain_pending_exception_handlers,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def server() -> FastAPI:
+    return FastAPI()
+
+
+@pytest.fixture
+def registry() -> ApplicationRegistry:
+    return ApplicationRegistry()
+
+
+@pytest.fixture
+def app_context(server: FastAPI, registry: ApplicationRegistry):
+    config = ApplicationContextConfig(properties_path="")
+    return ApplicationContext(config, server=server, registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# Drain functions
+# ---------------------------------------------------------------------------
+
+
+class TestDrainPendingRoutes:
+
+    @pytest.fixture(autouse=True)
+    def _clear_pending(self):
+        _pending_routes.clear()
+        yield
+        _pending_routes.clear()
+
+    def test_drain_returns_registered_routes(self):
+        class FakeController(RestController):
+            @GetMapping("/items")
+            def get_items(self):
+                pass
+
+        routes = drain_pending_routes()
+        assert len(routes) == 1
+        assert routes[0].path == "/items"
+        assert routes[0].method.value == "GET"
+
+    def test_drain_clears_pending_list(self):
+        class FakeController(RestController):
+            @GetMapping("/a")
+            def get_a(self):
+                pass
+
+            @PostMapping("/b")
+            def post_b(self):
+                pass
+
+        first = drain_pending_routes()
+        assert len(first) == 2
+
+        second = drain_pending_routes()
+        assert len(second) == 0
+
+    def test_drain_returns_routes_in_registration_order(self):
+        class FakeController(RestController):
+            @GetMapping("/first")
+            def first(self):
+                pass
+
+            @GetMapping("/second")
+            def second(self):
+                pass
+
+            @PostMapping("/third")
+            def third(self):
+                pass
+
+        routes = drain_pending_routes()
+        paths = [r.path for r in routes]
+        assert paths == ["/first", "/second", "/third"]
+
+
+class TestDrainPendingEventHandlers:
+
+    @pytest.fixture(autouse=True)
+    def _clear_pending(self):
+        _pending_event_handlers.clear()
+        yield
+        _pending_event_handlers.clear()
+
+    def test_drain_returns_registered_handlers(self):
+        from py_spring_core.event.application_event_handler_registry import (
+            _register_event_handler,
+        )
+
+        class MyEvent(ApplicationEvent):
+            pass
+
+        def handler(self, event):
+            pass
+
+        handler.__qualname__ = "MyComponent.on_event"
+        _register_event_handler(MyEvent, handler)
+
+        handlers = drain_pending_event_handlers()
+        assert len(handlers) == 1
+        assert handlers[0].event_type is MyEvent
+        assert handlers[0].class_name == "MyComponent"
+
+    def test_drain_clears_pending_list(self):
+        from py_spring_core.event.application_event_handler_registry import (
+            _register_event_handler,
+        )
+
+        class EventA(ApplicationEvent):
+            pass
+
+        def handler(self, event):
+            pass
+
+        handler.__qualname__ = "Comp.handle_a"
+        _register_event_handler(EventA, handler)
+
+        first = drain_pending_event_handlers()
+        assert len(first) == 1
+
+        second = drain_pending_event_handlers()
+        assert len(second) == 0
+
+    def test_duplicate_handler_not_added_twice(self):
+        """The same handler function should not be registered twice."""
+        from py_spring_core.event.application_event_handler_registry import (
+            _register_event_handler,
+        )
+
+        class EventB(ApplicationEvent):
+            pass
+
+        def handler_func(self, event):
+            pass
+
+        handler_func.__qualname__ = "SomeClass.handler_func"
+
+        _register_event_handler(EventB, handler_func)
+        _register_event_handler(EventB, handler_func)
+
+        handlers = drain_pending_event_handlers()
+        assert len(handlers) == 1
+
+
+class TestDrainPendingExceptionHandlers:
+
+    @pytest.fixture(autouse=True)
+    def _clear_pending(self):
+        _pending_exception_handlers.clear()
+        yield
+        _pending_exception_handlers.clear()
+
+    def test_drain_returns_registered_handlers(self):
+        class CustomError(Exception):
+            pass
+
+        def handler(exc: CustomError):
+            return "handled"
+
+        ExceptionHandlerRegistry.register(CustomError, handler)
+
+        drained = drain_pending_exception_handlers()
+        assert len(drained) == 1
+        assert drained[0][0] == "CustomError"
+
+    def test_drain_clears_pending_list(self):
+        class ErrorA(Exception):
+            pass
+
+        ExceptionHandlerRegistry.register(ErrorA, lambda e: None)
+
+        first = drain_pending_exception_handlers()
+        assert len(first) == 1
+
+        second = drain_pending_exception_handlers()
+        assert len(second) == 0
+
+    def test_duplicate_exception_handler_raises(self):
+        class ErrorB(Exception):
+            pass
+
+        ExceptionHandlerRegistry.register(ErrorB, lambda e: None)
+
+        with pytest.raises(RuntimeError, match="already registered"):
+            ExceptionHandlerRegistry.register(ErrorB, lambda e: None)
+
+
+# ---------------------------------------------------------------------------
+# ApplicationRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestApplicationRegistry:
+
+    def test_clear_resets_all_state(self):
+        reg = ApplicationRegistry()
+        reg.routes["TestCtrl"] = {
+            RouteRegistration(
+                class_name="TestCtrl",
+                method="GET",
+                path="/test",
+                func=lambda: None,
+            )
+        }
+        reg.event_handlers["MyEvent"] = [{"some": "handler"}]
+        reg.exception_handlers["ValueError"] = lambda e: None
+        reg.loaded_properties["db"] = {"host": "localhost"}
+        reg.event_queue.put("msg")
+
+        reg.clear()
+
+        assert reg.routes == {}
+        assert reg.event_handlers == {}
+        assert reg.exception_handlers == {}
+        assert reg.loaded_properties == {}
+        assert reg.event_queue.empty()
+
+    def test_two_registries_are_independent(self):
+        reg_a = ApplicationRegistry()
+        reg_b = ApplicationRegistry()
+
+        reg_a.routes["CtrlA"] = set()
+        reg_a.event_handlers["EvtA"] = []
+
+        assert "CtrlA" not in reg_b.routes
+        assert "EvtA" not in reg_b.event_handlers
+
+    def test_default_factory_creates_independent_instances(self):
+        """Each registry should have its own dict/queue, not shared references."""
+        reg_a = ApplicationRegistry()
+        reg_b = ApplicationRegistry()
+
+        assert reg_a.routes is not reg_b.routes
+        assert reg_a.event_handlers is not reg_b.event_handlers
+        assert reg_a.event_queue is not reg_b.event_queue
+
+
+# ---------------------------------------------------------------------------
+# Instance-level DI
+# ---------------------------------------------------------------------------
+
+
+class TestInstanceLevelDI:
+
+    def test_di_sets_on_instance_not_class(self, app_context: ApplicationContext):
+        """After injection, the dependency should be on the instance, not the class."""
+
+        class DepService(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+        class Consumer(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+            dep: DepService
+
+        app_context.register_component(DepService)
+        app_context.register_component(Consumer)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        instance = app_context.get_component(Consumer)
+        assert instance is not None
+        assert hasattr(instance, "dep")
+        assert isinstance(instance.dep, DepService)
+
+        # The class itself should NOT have the attribute set
+        assert "dep" not in Consumer.__dict__
+
+    def test_prototype_gets_fresh_di_per_instantiation(
+        self, app_context: ApplicationContext
+    ):
+        """Each prototype instance should get its own injected dependencies."""
+
+        class SharedSingleton(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+        class PrototypeConsumer(Component):
+            class Config:
+                scope = ComponentScope.Prototype
+
+            shared: SharedSingleton
+
+        app_context.register_component(SharedSingleton)
+        app_context.register_component(PrototypeConsumer)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        proto_a = app_context.get_component(PrototypeConsumer)
+        proto_b = app_context.get_component(PrototypeConsumer)
+
+        # Different instances
+        assert proto_a is not proto_b
+        # Both have the dependency injected
+        assert hasattr(proto_a, "shared")
+        assert hasattr(proto_b, "shared")
+        # Both point to the same singleton
+        assert proto_a.shared is proto_b.shared
+        assert isinstance(proto_a.shared, SharedSingleton)
+
+    def test_two_singletons_get_independent_instance_di(
+        self, app_context: ApplicationContext
+    ):
+        """Two different singletons that depend on the same type get the same
+        singleton instance (identity), but each via their own instance attribute."""
+
+        class SharedDep(Component):
+            class Config:
+                scope = ComponentScope.Singleton
+
+        class ConsumerA(Component):
+            class Config:
+                name = "ConsumerA"
+                scope = ComponentScope.Singleton
+
+            dep: SharedDep
+
+        class ConsumerB(Component):
+            class Config:
+                name = "ConsumerB"
+                scope = ComponentScope.Singleton
+
+            dep: SharedDep
+
+        app_context.register_component(SharedDep)
+        app_context.register_component(ConsumerA)
+        app_context.register_component(ConsumerB)
+        app_context.init_ioc_container()
+        app_context.inject_dependencies_for_app_entities()
+
+        a = app_context.get_component(ConsumerA)
+        b = app_context.get_component(ConsumerB)
+
+        assert a is not b
+        assert a.dep is b.dep  # same singleton
+        # Both are instance-level, not class-level
+        assert "dep" not in ConsumerA.__dict__
+        assert "dep" not in ConsumerB.__dict__
+
+
+# ---------------------------------------------------------------------------
+# Controller instance-level app/router
+# ---------------------------------------------------------------------------
+
+
+class TestControllerInstanceState:
+
+    def test_controller_init_has_none_app_router(self):
+        """A freshly constructed controller should have None app and router."""
+
+        class MyController(RestController):
+            pass
+
+        ctrl = MyController()
+        assert ctrl.app is None
+        assert ctrl.router is None
+
+    def test_controller_instances_have_independent_state(self):
+        """Two controller instances should have independent app/router."""
+
+        class CtrlA(RestController):
+            pass
+
+        class CtrlB(RestController):
+            pass
+
+        a = CtrlA()
+        b = CtrlB()
+
+        app_a = FastAPI()
+        app_b = FastAPI()
+
+        a.app = app_a
+        a.router = APIRouter(prefix="/a")
+        b.app = app_b
+        b.router = APIRouter(prefix="/b")
+
+        assert a.app is app_a
+        assert b.app is app_b
+        assert a.app is not b.app
+        assert a.router is not b.router
+
+
+# ---------------------------------------------------------------------------
+# Event queue through registry
+# ---------------------------------------------------------------------------
+
+
+class TestEventQueueThroughRegistry:
+
+    def test_event_queue_is_per_registry(self):
+        reg_a = ApplicationRegistry()
+        reg_b = ApplicationRegistry()
+
+        reg_a.event_queue.put("event_for_a")
+
+        assert not reg_b.event_queue.qsize()
+        assert reg_a.event_queue.qsize() == 1


### PR DESCRIPTION
## Summary

This PR eliminates global mutable class-level state scattered across multiple modules and consolidates it into a single, instance-owned `ApplicationRegistry`. Decorator registrations (routes, event handlers, exception handlers) that happen at import time are now staged in module-level pending lists and **drained** into the per-application registry during boot, enabling proper test isolation and multi-application support.

## Motivation

Previously, route mappings, event handlers, exception handlers, the event queue, and loaded properties were all stored as **class variables** (e.g., `RouteMapping.routes`, `ApplicationEventHandlerRegistry._class_event_handlers`, `ExceptionHandlerRegistry._handlers`, `EventQueue.queue`). This caused:

- **Test pollution**: State leaked between test runs since class variables persisted across instances.
- **Multi-app conflicts**: Running multiple `PySpringApplication` instances was impossible without shared state collisions.
- **Implicit coupling**: Components reached for global singletons instead of receiving dependencies explicitly.

## Changes

### New: `ApplicationRegistry` (dataclass)
A single dataclass that owns all mutable application state:
- `routes` — controller route registrations
- `event_handlers` — event listener bindings
- `exception_handlers` — exception handler mappings
- `loaded_properties` — properties loaded from config
- `event_queue` — the event message queue

Each `PySpringApplication` creates its own `ApplicationRegistry` and passes it into `ApplicationContext`.

### Drain Pattern for Import-Time Decorators
Since decorators like `@GetMapping`, `@EventListener`, and `@ExceptionHandler` execute at **import time** (before any application instance exists), we cannot write directly into an `ApplicationRegistry`. The solution is a two-phase approach:

1. **Stage**: Decorators append to module-level pending lists (`_pending_routes`, `_pending_event_handlers`, `_pending_exception_handlers`).
2. **Drain**: During `_init_app()`, `PySpringApplication._drain_pending_registrations()` moves all pending items into `self.registry` and clears the staging lists.

### Instance-Level Dependency Injection
- `DependencyInjector.inject_dependencies()` now operates on **instances** (`object`) rather than classes (`Type`), enabling proper per-instance injection.
- `RestController.app` and `RestController.router` are now instance attributes set during controller initialization, not class-level shared state.
- `BeanCollection` dependencies are injected into collection instances, not classes.
- Prototype-scoped components receive DI on every instantiation.

### Removed Global State
| Removed | Replaced By |
|---|---|
| `RouteMapping.routes` (class dict) | `ApplicationRegistry.routes` |
| `ApplicationEventHandlerRegistry._class_event_handlers` (ClassVar) | `ApplicationRegistry.event_handlers` |
| `ExceptionHandlerRegistry._handlers` (class dict) | `ApplicationRegistry.exception_handlers` |
| `EventQueue.queue` (class-level Queue) | `ApplicationRegistry.event_queue` |
| `_PropertiesLoader.optional_loaded_properties` (class var) | `ApplicationRegistry.loaded_properties` |
| `RestController.app` / `.router` (class vars) | Instance attributes set per controller |

### API Additions
- `ApplicationContext.must_get_component()` / `must_get_bean()` / `must_get_properties()` — non-optional getters that raise `LookupError`.
- `ApplicationContext.inject_dependencies_for_instance()` — inject DI into a specific object instance.
- `RestController.must_get_router()` — raises `LookupError` if router is uninitialized.
- `ExceptionHandler` decorator now uses `TypeVar` for precise exception typing.

## Draining Flow

The following diagram illustrates how import-time decorator registrations flow into the per-application registry:

```mermaid
sequenceDiagram
    participant Module as Python Module (import time)
    participant PendingRoutes as _pending_routes
    participant PendingEvents as _pending_event_handlers
    participant PendingExc as _pending_exception_handlers
    participant App as PySpringApplication
    participant Registry as ApplicationRegistry
    participant Context as ApplicationContext

    Note over Module: Phase 1 — Import Time (decorators fire)
    Module->>PendingRoutes: @GetMapping / @PostMapping / ...<br/>append(RouteRegistration)
    Module->>PendingEvents: @EventListener(EventType)<br/>append(EventHandler)
    Module->>PendingExc: @ExceptionHandler(ExcType)<br/>append((name, handler))

    Note over App: Phase 2 — Application Boot (_init_app)
    App->>App: _prepare_injected_classes()
    App->>App: _drain_pending_registrations()

    activate App
    App->>PendingRoutes: drain_pending_routes()
    PendingRoutes-->>App: list[RouteRegistration]
    App->>Registry: routes[class_name].add(route)

    App->>PendingEvents: drain_pending_event_handlers()
    PendingEvents-->>App: list[EventHandler]
    App->>Registry: event_handlers[event_name].append(handler)

    App->>PendingExc: drain_pending_exception_handlers()
    PendingExc-->>App: list[(exc_name, handler)]
    App->>Registry: exception_handlers[exc_name] = handler
    deactivate App

    Note over App: Phase 3 — Context Initialization
    App->>Context: inject dependencies (instance-level)
    App->>Context: register app entities
    App->>Context: load properties → registry.loaded_properties

    Note over App: Phase 4 — Controller Wiring
    App->>Context: get_controller_instances()
    loop Each controller
        App->>App: controller.app = fastapi
        App->>App: controller.router = APIRouter(prefix=...)
        App->>Context: inject_dependencies_for_instance(controller)
        App->>Registry: registry.routes.get(controller_name)
        App->>App: controller._register_decorated_routes(routes)
        App->>App: fastapi.include_router(router)
    end
```

```mermaid
graph TD
    subgraph "Import Time"
        A["@GetMapping('/items')"] -->|append| B[_pending_routes]
        C["@EventListener(OrderEvent)"] -->|append| D[_pending_event_handlers]
        E["@ExceptionHandler(ValueError)"] -->|append| F[_pending_exception_handlers]
    end

    subgraph "App Boot: _drain_pending_registrations()"
        B -->|drain_pending_routes| G[ApplicationRegistry.routes]
        D -->|drain_pending_event_handlers| H[ApplicationRegistry.event_handlers]
        F -->|drain_pending_exception_handlers| I[ApplicationRegistry.exception_handlers]
    end

    subgraph "Runtime"
        G -->|looked up per controller| J[RestController._register_decorated_routes]
        H -->|bound to components| K[ApplicationEventHandlerRegistry]
        I -->|used for error handling| L[Exception Middleware]
    end
```

## Test Plan

- [x] `test_global_state_refactor.py` — Unit tests for drain functions, registry isolation, instance-level DI, prototype DI, and controller instance attributes (452 lines).
- [x] `test_drain_e2e.py` — End-to-end tests verifying the full scan → drain → register → init sequence produces functional routes, event handlers, and exception handlers (491 lines).
- [x] `test_application_context.py` — Updated existing tests to align with instance-level injection changes.
- [x] All existing tests continue to pass.

## Files Changed

| File | Change |
|---|---|
| `application_registry.py` | **New** — central state dataclass |
| `py_spring_application.py` | Create registry, drain pending, instance-level controller init |
| `application_context.py` | Accept registry, instance-level DI, `must_get_*` methods |
| `route_mapping.py` | Replace class dict with pending list + drain function |
| `application_event_handler_registry.py` | Replace ClassVar with pending list + drain, read from registry |
| `exception_handler_registry.py` | Replace class dict with pending list + drain |
| `application_event_publisher.py` | Use registry queue via ApplicationContextRequired |
| `rest_controller.py` | Instance attributes, `must_get_router()` |
| `properties_loader.py` | Remove global `optional_loaded_properties` |
| `event/commons.py` | Remove `EventQueue` global |
| `exception_handler/decorator.py` | TypeVar for exception type |
| `test_global_state_refactor.py` | **New** — unit tests |
| `test_drain_e2e.py` | **New** — e2e tests |
| `test_application_context.py` | Updated for instance-level DI |
